### PR TITLE
Add native iOS SwiftUI app for Welsh vocabulary learning

### DIFF
--- a/ios/Geirfa.xcodeproj/project.pbxproj
+++ b/ios/Geirfa.xcodeproj/project.pbxproj
@@ -1,0 +1,444 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A100000000000000000001 /* GeirfaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000001 /* GeirfaApp.swift */; };
+		A100000000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000002 /* ContentView.swift */; };
+		A100000000000000000003 /* VocabularyItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000003 /* VocabularyItem.swift */; };
+		A100000000000000000004 /* SRCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000004 /* SRCard.swift */; };
+		A100000000000000000005 /* DeckViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000005 /* DeckViewModel.swift */; };
+		A100000000000000000006 /* UnitBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000006 /* UnitBarView.swift */; };
+		A100000000000000000007 /* FlashcardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000007 /* FlashcardView.swift */; };
+		A100000000000000000008 /* TypingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000008 /* TypingView.swift */; };
+		A100000000000000000009 /* ProgressBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B100000000000000000009 /* ProgressBarView.swift */; };
+		A10000000000000000000A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000A /* SettingsView.swift */; };
+		A10000000000000000000B /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000B /* ConfettiView.swift */; };
+		A10000000000000000000C /* ReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000C /* ReviewView.swift */; };
+		A10000000000000000000D /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000D /* StorageService.swift */; };
+		A10000000000000000000E /* CategoryColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000E /* CategoryColors.swift */; };
+		A10000000000000000000F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B10000000000000000000F /* Assets.xcassets */; };
+		A100000000000000000010 /* vocabulary.json in Resources */ = {isa = PBXBuildFile; fileRef = B100000000000000000010 /* vocabulary.json */; };
+		A100000000000000000011 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B100000000000000000011 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B100000000000000000001 /* GeirfaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeirfaApp.swift; sourceTree = "<group>"; };
+		B100000000000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B100000000000000000003 /* VocabularyItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyItem.swift; sourceTree = "<group>"; };
+		B100000000000000000004 /* SRCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SRCard.swift; sourceTree = "<group>"; };
+		B100000000000000000005 /* DeckViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeckViewModel.swift; sourceTree = "<group>"; };
+		B100000000000000000006 /* UnitBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitBarView.swift; sourceTree = "<group>"; };
+		B100000000000000000007 /* FlashcardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardView.swift; sourceTree = "<group>"; };
+		B100000000000000000008 /* TypingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingView.swift; sourceTree = "<group>"; };
+		B100000000000000000009 /* ProgressBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarView.swift; sourceTree = "<group>"; };
+		B10000000000000000000A /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		B10000000000000000000B /* ConfettiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
+		B10000000000000000000C /* ReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewView.swift; sourceTree = "<group>"; };
+		B10000000000000000000D /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
+		B10000000000000000000E /* CategoryColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryColors.swift; sourceTree = "<group>"; };
+		B10000000000000000000F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B100000000000000000010 /* vocabulary.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = vocabulary.json; sourceTree = "<group>"; };
+		B100000000000000000011 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		B100000000000000000020 /* Geirfa.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Geirfa.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D100000000000000000003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C100000000000000000001 = {
+			isa = PBXGroup;
+			children = (
+				C100000000000000000002 /* Geirfa */,
+				C100000000000000000009 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C100000000000000000002 /* Geirfa */ = {
+			isa = PBXGroup;
+			children = (
+				B100000000000000000001 /* GeirfaApp.swift */,
+				B100000000000000000002 /* ContentView.swift */,
+				C100000000000000000003 /* Models */,
+				C100000000000000000004 /* ViewModels */,
+				C100000000000000000005 /* Views */,
+				C100000000000000000006 /* Services */,
+				C100000000000000000007 /* Utilities */,
+				B10000000000000000000F /* Assets.xcassets */,
+				B100000000000000000010 /* vocabulary.json */,
+				C100000000000000000008 /* Preview Content */,
+			);
+			path = Geirfa;
+			sourceTree = "<group>";
+		};
+		C100000000000000000003 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B100000000000000000003 /* VocabularyItem.swift */,
+				B100000000000000000004 /* SRCard.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		C100000000000000000004 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				B100000000000000000005 /* DeckViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		C100000000000000000005 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B100000000000000000006 /* UnitBarView.swift */,
+				B100000000000000000007 /* FlashcardView.swift */,
+				B100000000000000000008 /* TypingView.swift */,
+				B100000000000000000009 /* ProgressBarView.swift */,
+				B10000000000000000000A /* SettingsView.swift */,
+				B10000000000000000000B /* ConfettiView.swift */,
+				B10000000000000000000C /* ReviewView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		C100000000000000000006 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				B10000000000000000000D /* StorageService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		C100000000000000000007 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				B10000000000000000000E /* CategoryColors.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		C100000000000000000008 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				B100000000000000000011 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		C100000000000000000009 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B100000000000000000020 /* Geirfa.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E100000000000000000001 /* Geirfa */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 120000000000000000000002 /* Build configuration list for PBXNativeTarget "Geirfa" */;
+			buildPhases = (
+				D100000000000000000001 /* Sources */,
+				D100000000000000000003 /* Frameworks */,
+				D100000000000000000002 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Geirfa;
+			productName = Geirfa;
+			productReference = B100000000000000000020 /* Geirfa.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F100000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					E100000000000000000001 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = 120000000000000000000001 /* Build configuration list for PBXProject "Geirfa" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+				cy,
+			);
+			mainGroup = C100000000000000000001;
+			productRefGroup = C100000000000000000009 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E100000000000000000001 /* Geirfa */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D100000000000000000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10000000000000000000F /* Assets.xcassets in Resources */,
+				A100000000000000000010 /* vocabulary.json in Resources */,
+				A100000000000000000011 /* Preview Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D100000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A100000000000000000001 /* GeirfaApp.swift in Sources */,
+				A100000000000000000002 /* ContentView.swift in Sources */,
+				A100000000000000000003 /* VocabularyItem.swift in Sources */,
+				A100000000000000000004 /* SRCard.swift in Sources */,
+				A100000000000000000005 /* DeckViewModel.swift in Sources */,
+				A100000000000000000006 /* UnitBarView.swift in Sources */,
+				A100000000000000000007 /* FlashcardView.swift in Sources */,
+				A100000000000000000008 /* TypingView.swift in Sources */,
+				A100000000000000000009 /* ProgressBarView.swift in Sources */,
+				A10000000000000000000A /* SettingsView.swift in Sources */,
+				A10000000000000000000B /* ConfettiView.swift in Sources */,
+				A10000000000000000000C /* ReviewView.swift in Sources */,
+				A10000000000000000000D /* StorageService.swift in Sources */,
+				A10000000000000000000E /* CategoryColors.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		110000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		110000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		110000000000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Geirfa/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Geirfa;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.geirfa.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		110000000000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Geirfa/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Geirfa;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.geirfa.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		120000000000000000000001 /* Build configuration list for PBXProject "Geirfa" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				110000000000000000000001 /* Debug */,
+				110000000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		120000000000000000000002 /* Build configuration list for PBXNativeTarget "Geirfa" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				110000000000000000000003 /* Debug */,
+				110000000000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F100000000000000000001 /* Project object */;
+}

--- a/ios/Geirfa/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/Geirfa/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.235",
+          "green" : "0.420",
+          "red" : "0.102"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Geirfa/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/Geirfa/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Geirfa/Assets.xcassets/Contents.json
+++ b/ios/Geirfa/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Geirfa/ContentView.swift
+++ b/ios/Geirfa/ContentView.swift
@@ -1,0 +1,255 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = DeckViewModel()
+
+    var body: some View {
+        ZStack {
+            // Background
+            (viewModel.isReviewMode ? AppColors.reviewBg : AppColors.cream)
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                // Header
+                header
+                    .padding(.bottom, 12)
+
+                // Unit bar
+                UnitBarView(viewModel: viewModel)
+                    .padding(.bottom, 8)
+
+                // Review banner
+                ReviewBanner(viewModel: viewModel)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 4)
+
+                // Progress bar
+                ProgressBarView(viewModel: viewModel)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+
+                Spacer()
+
+                // Card area
+                Group {
+                    if viewModel.mode == .flip {
+                        FlashcardView(viewModel: viewModel)
+                    } else {
+                        TypingView(viewModel: viewModel)
+                    }
+                }
+                .padding(.horizontal, 16)
+
+                Spacer()
+
+                // Action buttons
+                actionButtons
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 16)
+
+                // Review FAB
+                ReviewFAB(viewModel: viewModel)
+                    .padding(.bottom, 8)
+            }
+
+            // Mastery celebration
+            ConfettiView(isShowing: $viewModel.showMastery)
+        }
+        .onAppear {
+            viewModel.load()
+        }
+        .sheet(isPresented: $viewModel.showSettings) {
+            SettingsView(viewModel: viewModel)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 4) {
+            HStack {
+                Spacer()
+                VStack(spacing: 2) {
+                    HStack(spacing: 0) {
+                        Text("Geirfa")
+                            .font(.custom("Georgia", size: 28))
+                            .fontWeight(.bold)
+                            .foregroundColor(AppColors.dark)
+                        Text(".")
+                            .font(.custom("Georgia", size: 28))
+                            .fontWeight(.bold)
+                            .foregroundColor(AppColors.hgreen)
+                    }
+                    Text("WELSH VOCABULARY")
+                        .font(.system(size: 11, weight: .medium))
+                        .tracking(1.5)
+                        .foregroundColor(AppColors.mid)
+                }
+                Spacer()
+            }
+            .overlay(alignment: .trailing) {
+                Button {
+                    viewModel.showSettings = true
+                } label: {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 18))
+                        .foregroundColor(AppColors.mid)
+                        .frame(width: 36, height: 36)
+                        .background(.white)
+                        .clipShape(Circle())
+                        .overlay(
+                            Circle()
+                                .strokeBorder(AppColors.light, lineWidth: 1.5)
+                        )
+                }
+                .padding(.trailing, 16)
+            }
+        }
+        .padding(.top, 8)
+        .padding(.bottom, 8)
+        .overlay(alignment: .bottom) {
+            Divider()
+                .background(AppColors.light)
+        }
+    }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        VStack(spacing: 10) {
+            if viewModel.mode == .flip {
+                flipModeButtons
+            } else {
+                typingModeButtons
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var flipModeButtons: some View {
+        if viewModel.isFlipped {
+            // Rating buttons
+            HStack(spacing: 8) {
+                ratingButton("Hard", rating: 0, color: .red)
+                ratingButton("Okay", rating: 1, color: AppColors.gold)
+                ratingButton("Got it", rating: 2, color: AppColors.hgreen)
+            }
+        } else {
+            // Pre-flip buttons
+            HStack(spacing: 8) {
+                // Hint button
+                Button {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        viewModel.revealHint()
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "lightbulb")
+                        Text("Hint")
+                    }
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(AppColors.mid)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(AppColors.light, lineWidth: 1.5)
+                    )
+                }
+                .disabled(!viewModel.canHint)
+                .opacity(viewModel.canHint ? 1 : 0.35)
+
+                // Shuffle button
+                Button {
+                    viewModel.rebuildDeck()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "shuffle")
+                        Text("Shuffle")
+                    }
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(AppColors.mid)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(AppColors.light, lineWidth: 1.5)
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var typingModeButtons: some View {
+        if viewModel.typingResult != nil {
+            // After answer submitted — show rating buttons
+            HStack(spacing: 8) {
+                ratingButton("Hard", rating: 0, color: .red)
+                ratingButton("Okay", rating: 1, color: AppColors.gold)
+                ratingButton("Got it", rating: 2, color: AppColors.hgreen)
+            }
+        } else {
+            // Before answer — show check and hint buttons
+            HStack(spacing: 8) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        viewModel.revealHint()
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "lightbulb")
+                        Text("Hint")
+                    }
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(AppColors.mid)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .strokeBorder(AppColors.light, lineWidth: 1.5)
+                    )
+                }
+                .disabled(!viewModel.canHint)
+                .opacity(viewModel.canHint ? 1 : 0.35)
+
+                Button {
+                    viewModel.checkTypingAnswer()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark")
+                        Text("Check")
+                    }
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 22)
+                    .padding(.vertical, 10)
+                    .background(AppColors.dark)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .disabled(viewModel.typingAnswer.isEmpty)
+                .opacity(viewModel.typingAnswer.isEmpty ? 0.5 : 1)
+            }
+        }
+    }
+
+    private func ratingButton(_ label: String, rating: Int, color: Color) -> some View {
+        Button {
+            viewModel.rateCard(rating)
+        } label: {
+            Text(label)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(color)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+}

--- a/ios/Geirfa/GeirfaApp.swift
+++ b/ios/Geirfa/GeirfaApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct GeirfaApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/Geirfa/Models/SRCard.swift
+++ b/ios/Geirfa/Models/SRCard.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct SRCard: Codable {
+    var pile: Int       // 0 = hard, 1 = okay, 2 = got it
+    var box: Int        // 0-8 Leitner box
+    var streak: Int
+    var reviewAfter: Date
+    var totalReviews: Int
+    var totalCorrect: Int
+
+    static let boxIntervals = [0, 1, 3, 7, 14, 30, 90, 180, 365]
+
+    static func new() -> SRCard {
+        SRCard(pile: 0, box: 0, streak: 0, reviewAfter: .distantPast,
+               totalReviews: 0, totalCorrect: 0)
+    }
+
+    var isOverdue: Bool {
+        Date() >= reviewAfter
+    }
+
+    var urgencyRatio: Double {
+        guard pile == 2, reviewAfter < Date() else { return 0 }
+        let interval = SRCard.boxIntervals[min(box, SRCard.boxIntervals.count - 1)]
+        guard interval > 0 else { return 0 }
+        let overdueDays = Date().timeIntervalSince(reviewAfter) / 86400
+        return overdueDays / Double(interval)
+    }
+}

--- a/ios/Geirfa/Models/VocabularyItem.swift
+++ b/ios/Geirfa/Models/VocabularyItem.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+struct VocabularyItem: Codable, Identifiable {
+    let id: Int
+    let wordEnglish: String
+    let wordWelsh: String
+    let category: String
+    let level: String
+    let unit: String
+
+    enum CodingKeys: String, CodingKey {
+        case wordEnglish = "word_english"
+        case wordWelsh = "word_welsh"
+        case category, level, unit
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.wordEnglish = try container.decode(String.self, forKey: .wordEnglish)
+        self.wordWelsh = try container.decode(String.self, forKey: .wordWelsh)
+        self.category = try container.decode(String.self, forKey: .category)
+        self.level = try container.decode(String.self, forKey: .level)
+        self.unit = try container.decode(String.self, forKey: .unit)
+        // id is set after decoding via setIndex
+        self.id = 0
+    }
+
+    init(id: Int, wordEnglish: String, wordWelsh: String, category: String, level: String, unit: String) {
+        self.id = id
+        self.wordEnglish = wordEnglish
+        self.wordWelsh = wordWelsh
+        self.category = category
+        self.level = level
+        self.unit = unit
+    }
+
+    func withIndex(_ index: Int) -> VocabularyItem {
+        VocabularyItem(id: index, wordEnglish: wordEnglish, wordWelsh: wordWelsh,
+                       category: category, level: level, unit: unit)
+    }
+
+    var categoryKey: CategoryType {
+        switch category.lowercased() {
+        case let c where c.contains("feminine"):
+            return .feminine
+        case let c where c.contains("masculine"):
+            return .masculine
+        case "verb":
+            return .verb
+        case "adjective":
+            return .adjective
+        default:
+            return .other
+        }
+    }
+}
+
+enum CategoryType: String, CaseIterable {
+    case feminine
+    case masculine
+    case verb
+    case adjective
+    case other
+}
+
+enum Direction: String, Codable {
+    case englishToWelsh
+    case welshToEnglish
+}
+
+enum LearningMode: String, Codable {
+    case flip
+    case typing
+}

--- a/ios/Geirfa/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/ios/Geirfa/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/Geirfa/Services/StorageService.swift
+++ b/ios/Geirfa/Services/StorageService.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+final class StorageService {
+    static let shared = StorageService()
+
+    private let defaults = UserDefaults.standard
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    private enum Keys {
+        static let srCards = "welsh_sr_cards"
+        static let currentUnit = "welsh_current_unit"
+        static let direction = "welsh_direction"
+        static let mode = "welsh_mode"
+        static let masteredUnits = "welsh_mastered_units"
+    }
+
+    private init() {}
+
+    // MARK: - SR Cards
+
+    func loadSRCards() -> [String: SRCard] {
+        guard let data = defaults.data(forKey: Keys.srCards),
+              let cards = try? decoder.decode([String: SRCard].self, from: data) else {
+            return [:]
+        }
+        return cards
+    }
+
+    func saveSRCards(_ cards: [String: SRCard]) {
+        if let data = try? encoder.encode(cards) {
+            defaults.set(data, forKey: Keys.srCards)
+        }
+    }
+
+    // MARK: - Unit
+
+    var currentUnit: String {
+        get { defaults.string(forKey: Keys.currentUnit) ?? "1" }
+        set { defaults.set(newValue, forKey: Keys.currentUnit) }
+    }
+
+    // MARK: - Direction
+
+    var direction: Direction {
+        get {
+            guard let raw = defaults.string(forKey: Keys.direction),
+                  let dir = Direction(rawValue: raw) else { return .englishToWelsh }
+            return dir
+        }
+        set { defaults.set(newValue.rawValue, forKey: Keys.direction) }
+    }
+
+    // MARK: - Mode
+
+    var mode: LearningMode {
+        get {
+            guard let raw = defaults.string(forKey: Keys.mode),
+                  let m = LearningMode(rawValue: raw) else { return .flip }
+            return m
+        }
+        set { defaults.set(newValue.rawValue, forKey: Keys.mode) }
+    }
+
+    // MARK: - Mastered Units
+
+    func loadMasteredUnits() -> Set<String> {
+        guard let data = defaults.data(forKey: Keys.masteredUnits),
+              let units = try? decoder.decode(Set<String>.self, from: data) else {
+            return []
+        }
+        return units
+    }
+
+    func saveMasteredUnits(_ units: Set<String>) {
+        if let data = try? encoder.encode(units) {
+            defaults.set(data, forKey: Keys.masteredUnits)
+        }
+    }
+}

--- a/ios/Geirfa/Utilities/CategoryColors.swift
+++ b/ios/Geirfa/Utilities/CategoryColors.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+extension CategoryType {
+    var color: Color {
+        switch self {
+        case .feminine:  return Color(red: 0.722, green: 0.196, blue: 0.196) // #b83232
+        case .masculine: return Color(red: 0.141, green: 0.443, blue: 0.639) // #2471a3
+        case .verb:      return Color(red: 0.478, green: 0.478, blue: 0.478) // #7a7a7a
+        case .adjective: return Color(red: 0.102, green: 0.420, blue: 0.235) // #1a6b3c
+        case .other:     return Color(red: 0.490, green: 0.373, blue: 0.647) // #7d5fa5
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .feminine:  return "feminine noun"
+        case .masculine: return "masculine noun"
+        case .verb:      return "verb"
+        case .adjective: return "adjective"
+        case .other:     return "other"
+        }
+    }
+}
+
+enum AppColors {
+    static let cream = Color(red: 0.980, green: 0.969, blue: 0.949)       // #faf7f2
+    static let dark = Color(red: 0.110, green: 0.110, blue: 0.110)        // #1c1c1c
+    static let mid = Color(red: 0.353, green: 0.353, blue: 0.353)         // #5a5a5a
+    static let light = Color(red: 0.910, green: 0.886, blue: 0.851)      // #e8e2d9
+    static let gold = Color(red: 0.784, green: 0.659, blue: 0.294)       // #c8a84b
+    static let hgreen = Color(red: 0.102, green: 0.420, blue: 0.235)     // #1a6b3c
+    static let reviewBg = Color(red: 0.949, green: 0.937, blue: 0.894)   // #f2efe4
+}

--- a/ios/Geirfa/ViewModels/DeckViewModel.swift
+++ b/ios/Geirfa/ViewModels/DeckViewModel.swift
@@ -1,0 +1,401 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class DeckViewModel: ObservableObject {
+    // MARK: - Published State
+
+    @Published var allVocab: [VocabularyItem] = []
+    @Published var currentUnit: String = "1"
+    @Published var direction: Direction = .englishToWelsh
+    @Published var mode: LearningMode = .flip
+    @Published var deck: [Int] = []           // indices into allVocab
+    @Published var currentIndex: Int = 0
+    @Published var isFlipped: Bool = false
+    @Published var srCards: [String: SRCard] = [:]
+    @Published var masteredUnits: Set<String> = []
+    @Published var isReviewMode: Bool = false
+    @Published var hintLevel: Int = 0
+    @Published var showMastery: Bool = false
+    @Published var showSettings: Bool = false
+    @Published var typingAnswer: String = ""
+    @Published var typingResult: TypingResult? = nil
+
+    enum TypingResult {
+        case correct
+        case incorrect(correct: String)
+    }
+
+    private let storage = StorageService.shared
+
+    // MARK: - Computed Properties
+
+    var units: [String] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for item in allVocab {
+            if seen.insert(item.unit).inserted {
+                ordered.append(item.unit)
+            }
+        }
+        return ordered
+    }
+
+    var unitVocab: [VocabularyItem] {
+        allVocab.filter { $0.unit == currentUnit }
+    }
+
+    var currentCard: VocabularyItem? {
+        guard currentIndex >= 0, currentIndex < deck.count else { return nil }
+        let vocabIndex = deck[currentIndex]
+        guard vocabIndex < allVocab.count else { return nil }
+        return allVocab[vocabIndex]
+    }
+
+    var promptWord: String {
+        guard let card = currentCard else { return "" }
+        return direction == .englishToWelsh ? card.wordEnglish : card.wordWelsh
+    }
+
+    var answerWord: String {
+        guard let card = currentCard else { return "" }
+        return direction == .englishToWelsh ? card.wordWelsh : card.wordEnglish
+    }
+
+    var promptLabel: String {
+        direction == .englishToWelsh ? "ENGLISH" : "CYMRAEG"
+    }
+
+    var answerLabel: String {
+        direction == .englishToWelsh ? "CYMRAEG" : "ENGLISH"
+    }
+
+    var progressFraction: Double {
+        guard !deck.isEmpty else { return 0 }
+        return Double(currentIndex) / Double(deck.count)
+    }
+
+    var progressText: String {
+        guard !deck.isEmpty else { return "0 / 0" }
+        return "\(currentIndex + 1) / \(deck.count)"
+    }
+
+    var pileStats: (hard: Int, okay: Int, known: Int) {
+        let vocabIndices = unitVocab.map { $0.id }
+        var hard = 0, okay = 0, known = 0
+        for idx in vocabIndices {
+            let card = srCards[String(idx)]
+            switch card?.pile {
+            case 0: hard += 1
+            case 1: okay += 1
+            case 2: known += 1
+            default: hard += 1 // unseen cards count as hard
+            }
+        }
+        return (hard, okay, known)
+    }
+
+    var overdueCount: Int {
+        srCards.values.filter { $0.pile == 2 && $0.isOverdue }.count
+    }
+
+    var canShowReviewButton: Bool {
+        overdueCount > 0
+    }
+
+    // MARK: - Hints (Welsh digraph-aware)
+
+    private static let welshDigraphs = ["ch", "dd", "ff", "ng", "ll", "ph", "rh", "th"]
+
+    func welshLetters(_ word: String) -> [String] {
+        var letters: [String] = []
+        let lower = word.lowercased()
+        var i = lower.startIndex
+        while i < lower.endIndex {
+            var matched = false
+            for digraph in Self.welshDigraphs {
+                if lower[i...].hasPrefix(digraph) {
+                    letters.append(String(word[i..<word.index(i, offsetBy: digraph.count)]))
+                    i = word.index(i, offsetBy: digraph.count)
+                    matched = true
+                    break
+                }
+            }
+            if !matched {
+                letters.append(String(word[i]))
+                i = word.index(after: i)
+            }
+        }
+        return letters
+    }
+
+    var hintText: String {
+        guard hintLevel > 0 else { return "" }
+        let targetWord = direction == .englishToWelsh ? (currentCard?.wordWelsh ?? "") : (currentCard?.wordEnglish ?? "")
+        let letters = welshLetters(targetWord)
+        let revealed = min(hintLevel, letters.count)
+        return letters.prefix(revealed).joined()
+    }
+
+    var canHint: Bool {
+        guard let card = currentCard else { return false }
+        let targetWord = direction == .englishToWelsh ? card.wordWelsh : card.wordEnglish
+        return hintLevel < welshLetters(targetWord).count
+    }
+
+    // MARK: - Initialization
+
+    func load() {
+        loadVocabulary()
+        srCards = storage.loadSRCards()
+        currentUnit = storage.currentUnit
+        direction = storage.direction
+        mode = storage.mode
+        masteredUnits = storage.loadMasteredUnits()
+        rebuildDeck()
+    }
+
+    private func loadVocabulary() {
+        guard let url = Bundle.main.url(forResource: "vocabulary", withExtension: "json"),
+              let data = try? Data(contentsOf: url) else { return }
+        let decoder = JSONDecoder()
+        guard let items = try? decoder.decode([VocabularyItem].self, from: data) else { return }
+        allVocab = items.enumerated().map { $0.element.withIndex($0.offset) }
+    }
+
+    // MARK: - Deck Management
+
+    func rebuildDeck() {
+        let vocabForUnit = allVocab.filter { $0.unit == currentUnit }
+
+        var hardPile: [Int] = []
+        var okayPile: [Int] = []
+        var knownPile: [Int] = []
+
+        for item in vocabForUnit {
+            let key = String(item.id)
+            guard let card = srCards[key] else {
+                hardPile.append(item.id)
+                continue
+            }
+            switch card.pile {
+            case 0: hardPile.append(item.id)
+            case 1: okayPile.append(item.id)
+            case 2: knownPile.append(item.id)
+            default: hardPile.append(item.id)
+            }
+        }
+
+        hardPile.shuffle()
+        okayPile.shuffle()
+        knownPile.shuffle()
+
+        deck = hardPile + okayPile + knownPile
+        currentIndex = 0
+        isFlipped = false
+        hintLevel = 0
+        typingAnswer = ""
+        typingResult = nil
+    }
+
+    // MARK: - Unit Selection
+
+    func selectUnit(_ unit: String) {
+        guard unit != currentUnit || isReviewMode else { return }
+        isReviewMode = false
+        currentUnit = unit
+        storage.currentUnit = unit
+        rebuildDeck()
+    }
+
+    // MARK: - Direction & Mode
+
+    func toggleDirection() {
+        setDirection(direction == .englishToWelsh ? .welshToEnglish : .englishToWelsh)
+    }
+
+    func setDirection(_ dir: Direction) {
+        direction = dir
+        storage.direction = dir
+        isFlipped = false
+        hintLevel = 0
+    }
+
+    func setMode(_ newMode: LearningMode) {
+        mode = newMode
+        storage.mode = newMode
+        isFlipped = false
+        typingAnswer = ""
+        typingResult = nil
+        hintLevel = 0
+    }
+
+    // MARK: - Card Interaction
+
+    func flipCard() {
+        guard !deck.isEmpty else { return }
+        isFlipped.toggle()
+    }
+
+    func revealHint() {
+        hintLevel += 1
+    }
+
+    // MARK: - Rating
+
+    func rateCard(_ rating: Int) {
+        guard let card = currentCard else { return }
+        let key = String(card.id)
+        var sr = srCards[key] ?? SRCard.new()
+
+        sr.totalReviews += 1
+
+        switch rating {
+        case 0: // Hard
+            sr.pile = 0
+            sr.box = max(0, sr.box - 5)
+            sr.streak = 0
+            sr.reviewAfter = Date()
+        case 1: // Okay
+            sr.pile = 1
+            sr.box = max(0, sr.box - 3)
+            sr.streak = 0
+            sr.reviewAfter = Date()
+        case 2: // Got it
+            sr.pile = 2
+            sr.box = min(SRCard.boxIntervals.count - 1, sr.box + 1)
+            sr.streak += 1
+            sr.totalCorrect += 1
+            let interval = SRCard.boxIntervals[sr.box]
+            sr.reviewAfter = Calendar.current.date(byAdding: .day, value: interval, to: Date()) ?? Date()
+        default:
+            break
+        }
+
+        srCards[key] = sr
+        storage.saveSRCards(srCards)
+
+        // Check mastery
+        if !isReviewMode {
+            checkMastery()
+        }
+
+        advanceCard()
+    }
+
+    private func advanceCard() {
+        isFlipped = false
+        hintLevel = 0
+        typingAnswer = ""
+        typingResult = nil
+
+        if isReviewMode {
+            // In review mode, remove current card and stay at same index
+            if currentIndex < deck.count {
+                deck.remove(at: currentIndex)
+            }
+            if deck.isEmpty {
+                exitReview()
+                return
+            }
+            if currentIndex >= deck.count {
+                currentIndex = 0
+            }
+        } else {
+            if currentIndex + 1 < deck.count {
+                currentIndex += 1
+            } else {
+                // End of deck — rebuild to reorder by piles
+                rebuildDeck()
+            }
+        }
+    }
+
+    private func checkMastery() {
+        let vocabForUnit = allVocab.filter { $0.unit == currentUnit }
+        let allKnown = vocabForUnit.allSatisfy { item in
+            srCards[String(item.id)]?.pile == 2
+        }
+        if allKnown && !masteredUnits.contains(currentUnit) {
+            masteredUnits.insert(currentUnit)
+            storage.saveMasteredUnits(masteredUnits)
+            showMastery = true
+        }
+    }
+
+    func dismissMastery() {
+        showMastery = false
+    }
+
+    // MARK: - Review Mode
+
+    func startReview() {
+        let overdue = srCards.filter { $0.value.pile == 2 && $0.value.isOverdue }
+        let sorted = overdue.sorted { $0.value.urgencyRatio > $1.value.urgencyRatio }
+        let top = Array(sorted.prefix(20).shuffled().prefix(10))
+
+        guard !top.isEmpty else { return }
+
+        isReviewMode = true
+        deck = top.compactMap { Int($0.key) }
+        currentIndex = 0
+        isFlipped = false
+        hintLevel = 0
+    }
+
+    func exitReview() {
+        isReviewMode = false
+        rebuildDeck()
+    }
+
+    // MARK: - Review by Pile
+
+    func reviewPile(_ pile: Int) {
+        let vocabForUnit = allVocab.filter { $0.unit == currentUnit }
+        var pileCards: [Int] = []
+
+        for item in vocabForUnit {
+            let key = String(item.id)
+            let card = srCards[key]
+            let currentPile = card?.pile ?? 0
+            if currentPile == pile || (pile == 0 && card == nil) {
+                pileCards.append(item.id)
+            }
+        }
+
+        guard !pileCards.isEmpty else { return }
+
+        isReviewMode = true
+        deck = pileCards.shuffled()
+        currentIndex = 0
+        isFlipped = false
+        hintLevel = 0
+    }
+
+    // MARK: - Typing Mode
+
+    func checkTypingAnswer() {
+        let correct = answerWord
+        let normalizedAnswer = typingAnswer.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedCorrect = correct.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if normalizedAnswer == normalizedCorrect {
+            typingResult = .correct
+        } else {
+            typingResult = .incorrect(correct: correct)
+        }
+    }
+
+    func unitMasteryState(_ unit: String) -> UnitMastery {
+        if masteredUnits.contains(unit) { return .mastered }
+        let vocabForUnit = allVocab.filter { $0.unit == unit }
+        let hasProgress = vocabForUnit.contains { srCards[String($0.id)] != nil }
+        return hasProgress ? .partial : .none
+    }
+}
+
+enum UnitMastery {
+    case none
+    case partial
+    case mastered
+}

--- a/ios/Geirfa/Views/ConfettiView.swift
+++ b/ios/Geirfa/Views/ConfettiView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct ConfettiView: View {
+    @Binding var isShowing: Bool
+    @State private var particles: [ConfettiParticle] = []
+    @State private var animating = false
+
+    var body: some View {
+        if isShowing {
+            ZStack {
+                // Semi-transparent overlay
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+                    .onTapGesture { isShowing = false }
+
+                // Confetti particles
+                ForEach(particles) { particle in
+                    Circle()
+                        .fill(particle.color)
+                        .frame(width: particle.size, height: particle.size)
+                        .offset(
+                            x: animating ? particle.endX : particle.startX,
+                            y: animating ? particle.endY : particle.startY
+                        )
+                        .opacity(animating ? 0 : 1)
+                }
+
+                // Mastery message
+                VStack(spacing: 16) {
+                    Text("Da iawn!")
+                        .font(.custom("Georgia", size: 32))
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+
+                    Text("Unit mastered!")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundColor(.white.opacity(0.85))
+
+                    Button {
+                        isShowing = false
+                    } label: {
+                        Text("Continue")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(AppColors.hgreen)
+                            .padding(.horizontal, 24)
+                            .padding(.vertical, 10)
+                            .background(.white)
+                            .clipShape(Capsule())
+                    }
+                    .padding(.top, 8)
+                }
+            }
+            .onAppear {
+                generateParticles()
+                withAnimation(.easeOut(duration: 2.5)) {
+                    animating = true
+                }
+            }
+            .onDisappear {
+                animating = false
+                particles = []
+            }
+        }
+    }
+
+    private func generateParticles() {
+        let colors: [Color] = [.red, .orange, .yellow, .green, .blue, .purple, .pink, AppColors.gold]
+        particles = (0..<40).map { _ in
+            ConfettiParticle(
+                color: colors.randomElement() ?? .yellow,
+                size: CGFloat.random(in: 5...12),
+                startX: CGFloat.random(in: -20...20),
+                startY: -50,
+                endX: CGFloat.random(in: -180...180),
+                endY: CGFloat.random(in: 200...500)
+            )
+        }
+    }
+}
+
+struct ConfettiParticle: Identifiable {
+    let id = UUID()
+    let color: Color
+    let size: CGFloat
+    let startX: CGFloat
+    let startY: CGFloat
+    let endX: CGFloat
+    let endY: CGFloat
+}

--- a/ios/Geirfa/Views/FlashcardView.swift
+++ b/ios/Geirfa/Views/FlashcardView.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+struct FlashcardView: View {
+    @ObservedObject var viewModel: DeckViewModel
+
+    var body: some View {
+        if let card = viewModel.currentCard {
+            cardContent(card)
+                .id("\(card.id)-\(viewModel.currentIndex)")
+        } else {
+            emptyState
+        }
+    }
+
+    private func cardContent(_ card: VocabularyItem) -> some View {
+        VStack(spacing: 0) {
+            // Card
+            ZStack {
+                // Front face
+                frontFace(card)
+                    .opacity(viewModel.isFlipped ? 0 : 1)
+                    .rotation3DEffect(
+                        .degrees(viewModel.isFlipped ? 180 : 0),
+                        axis: (x: 0, y: 1, z: 0)
+                    )
+
+                // Back face
+                backFace(card)
+                    .opacity(viewModel.isFlipped ? 1 : 0)
+                    .rotation3DEffect(
+                        .degrees(viewModel.isFlipped ? 0 : -180),
+                        axis: (x: 0, y: 1, z: 0)
+                    )
+            }
+            .frame(height: 290)
+            .onTapGesture {
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    viewModel.flipCard()
+                }
+            }
+
+            // Hint text
+            if viewModel.hintLevel > 0 && !viewModel.isFlipped {
+                HStack(spacing: 4) {
+                    Text("Hint:")
+                        .font(.system(size: 14))
+                        .foregroundColor(AppColors.mid)
+                    Text(viewModel.hintText)
+                        .font(.system(size: 20, weight: .bold, design: .default))
+                        .foregroundColor(.red)
+                        .tracking(2)
+                }
+                .padding(.top, 8)
+                .transition(.opacity)
+            }
+        }
+    }
+
+    private func frontFace(_ card: VocabularyItem) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.white)
+                .shadow(color: .black.opacity(0.1), radius: 16, y: 8)
+                .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .strokeBorder(AppColors.light, lineWidth: 1.5)
+                )
+
+            VStack(spacing: 0) {
+                // Category label top-left
+                HStack {
+                    Text(card.category.uppercased())
+                        .font(.system(size: 11, weight: .bold))
+                        .tracking(0.7)
+                        .foregroundColor(AppColors.mid.opacity(0.4))
+                    Spacer()
+
+                    // Pile badge
+                    if let sr = viewModel.srCards[String(card.id)] {
+                        pileBadge(sr.pile)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 14)
+
+                Spacer()
+
+                Text(viewModel.promptLabel)
+                    .font(.system(size: 11, weight: .semibold))
+                    .tracking(1)
+                    .foregroundColor(AppColors.mid.opacity(0.45))
+                    .padding(.bottom, 12)
+
+                Text(viewModel.promptWord)
+                    .font(.custom("Georgia", size: 24))
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(AppColors.dark)
+                    .padding(.horizontal, 24)
+
+                Spacer()
+
+                Text("Tap to flip")
+                    .font(.system(size: 12))
+                    .foregroundColor(AppColors.mid.opacity(0.3))
+                    .tracking(0.7)
+                    .padding(.bottom, 20)
+            }
+        }
+    }
+
+    private func backFace(_ card: VocabularyItem) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(card.categoryKey.color)
+                .shadow(color: .black.opacity(0.1), radius: 16, y: 8)
+                .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+
+            VStack(spacing: 12) {
+                Text(viewModel.answerLabel)
+                    .font(.system(size: 11, weight: .semibold))
+                    .tracking(1)
+                    .foregroundColor(.white.opacity(0.5))
+
+                Text(viewModel.answerWord)
+                    .font(.custom("Georgia", size: 28))
+                    .fontWeight(.bold)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 24)
+
+                Text(card.category.uppercased())
+                    .font(.system(size: 12, weight: .semibold))
+                    .tracking(0.8)
+                    .padding(.horizontal, 11)
+                    .padding(.vertical, 4)
+                    .background(.white.opacity(0.2))
+                    .clipShape(Capsule())
+                    .foregroundColor(.white)
+            }
+        }
+    }
+
+    private func pileBadge(_ pile: Int) -> some View {
+        let (text, color): (String, Color) = {
+            switch pile {
+            case 0: return ("H", Color.red)
+            case 1: return ("O", AppColors.gold)
+            case 2: return ("G", AppColors.hgreen)
+            default: return ("", .clear)
+            }
+        }()
+
+        return Text(text)
+            .font(.system(size: 10, weight: .bold))
+            .foregroundColor(color)
+            .frame(width: 20, height: 20)
+            .background(color.opacity(0.15))
+            .clipShape(Circle())
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 48))
+                .foregroundColor(AppColors.hgreen)
+            Text("No cards to review")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(AppColors.mid)
+        }
+        .frame(height: 290)
+    }
+}

--- a/ios/Geirfa/Views/ProgressBarView.swift
+++ b/ios/Geirfa/Views/ProgressBarView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct ProgressBarView: View {
+    @ObservedObject var viewModel: DeckViewModel
+
+    var body: some View {
+        VStack(spacing: 5) {
+            HStack {
+                Text(viewModel.progressText)
+                    .font(.system(size: 12))
+                    .foregroundColor(AppColors.mid)
+                Spacer()
+                Text("\(Int(viewModel.progressFraction * 100))%")
+                    .font(.system(size: 12))
+                    .foregroundColor(AppColors.mid)
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(AppColors.light)
+                        .frame(height: 4)
+
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(viewModel.isReviewMode ? AppColors.gold : AppColors.hgreen)
+                        .frame(width: max(0, geo.size.width * viewModel.progressFraction), height: 4)
+                        .animation(.easeInOut(duration: 0.4), value: viewModel.progressFraction)
+                }
+            }
+            .frame(height: 4)
+        }
+    }
+}

--- a/ios/Geirfa/Views/ReviewView.swift
+++ b/ios/Geirfa/Views/ReviewView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct ReviewBanner: View {
+    @ObservedObject var viewModel: DeckViewModel
+
+    var body: some View {
+        if viewModel.isReviewMode {
+            HStack {
+                Image(systemName: "arrow.clockwise.circle.fill")
+                    .foregroundColor(AppColors.gold)
+                Text("Review Mode")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(AppColors.gold)
+                Text("(\(viewModel.deck.count) cards)")
+                    .font(.system(size: 13))
+                    .foregroundColor(AppColors.mid)
+                Spacer()
+                Button {
+                    viewModel.exitReview()
+                } label: {
+                    Text("Exit")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 4)
+                        .background(Color.red.opacity(0.1))
+                        .clipShape(Capsule())
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(AppColors.reviewBg)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+    }
+}
+
+struct ReviewFAB: View {
+    @ObservedObject var viewModel: DeckViewModel
+
+    var body: some View {
+        if viewModel.canShowReviewButton && !viewModel.isReviewMode {
+            Button {
+                viewModel.startReview()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 14, weight: .semibold))
+                    Text("Review \(viewModel.overdueCount)")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .foregroundColor(.white)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 10)
+                .background(AppColors.gold)
+                .clipShape(Capsule())
+                .shadow(color: AppColors.gold.opacity(0.3), radius: 8, y: 4)
+            }
+        }
+    }
+}

--- a/ios/Geirfa/Views/SettingsView.swift
+++ b/ios/Geirfa/Views/SettingsView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var viewModel: DeckViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Direction") {
+                    Picker("Direction", selection: $viewModel.direction) {
+                        Text("English \u{2192} Cymraeg").tag(Direction.englishToWelsh)
+                        Text("Cymraeg \u{2192} English").tag(Direction.welshToEnglish)
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: viewModel.direction) { newDir in
+                        viewModel.setDirection(newDir)
+                    }
+                }
+
+                Section("Learning Mode") {
+                    Picker("Mode", selection: $viewModel.mode) {
+                        Label("Flip Cards", systemImage: "rectangle.on.rectangle.angled")
+                            .tag(LearningMode.flip)
+                        Label("Typing", systemImage: "keyboard")
+                            .tag(LearningMode.typing)
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: viewModel.mode) { newMode in
+                        viewModel.setMode(newMode)
+                    }
+                }
+
+                Section("Unit Statistics") {
+                    let stats = viewModel.pileStats
+                    HStack(spacing: 16) {
+                        StatBadge(label: "Hard", count: stats.hard, color: .red) {
+                            if stats.hard > 0 { viewModel.reviewPile(0); dismiss() }
+                        }
+                        StatBadge(label: "Okay", count: stats.okay, color: AppColors.gold) {
+                            if stats.okay > 0 { viewModel.reviewPile(1); dismiss() }
+                        }
+                        StatBadge(label: "Known", count: stats.known, color: AppColors.hgreen) {
+                            if stats.known > 0 { viewModel.reviewPile(2); dismiss() }
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .listRowBackground(Color.clear)
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct StatBadge: View {
+    let label: String
+    let count: Int
+    let color: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                Text("\(count)")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundColor(color)
+                Text(label)
+                    .font(.system(size: 11, weight: .semibold))
+                    .tracking(0.5)
+                    .foregroundColor(AppColors.mid)
+            }
+            .frame(minWidth: 70)
+            .padding(.vertical, 8)
+            .background(color.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .disabled(count == 0)
+        .opacity(count == 0 ? 0.4 : 1)
+    }
+}

--- a/ios/Geirfa/Views/TypingView.swift
+++ b/ios/Geirfa/Views/TypingView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+struct TypingView: View {
+    @ObservedObject var viewModel: DeckViewModel
+    @FocusState private var isInputFocused: Bool
+
+    var body: some View {
+        if let card = viewModel.currentCard {
+            typingCard(card)
+                .id("\(card.id)-\(viewModel.currentIndex)")
+        } else {
+            emptyState
+        }
+    }
+
+    private func typingCard(_ card: VocabularyItem) -> some View {
+        VStack(spacing: 0) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(.white)
+                    .shadow(color: .black.opacity(0.1), radius: 16, y: 8)
+                    .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .strokeBorder(borderColor, lineWidth: 1.5)
+                    )
+
+                VStack(spacing: 16) {
+                    // Category label
+                    Text(card.category.uppercased())
+                        .font(.system(size: 11, weight: .bold))
+                        .tracking(0.7)
+                        .foregroundColor(AppColors.mid.opacity(0.4))
+
+                    // Prompt label
+                    Text(viewModel.promptLabel)
+                        .font(.system(size: 11, weight: .semibold))
+                        .tracking(1)
+                        .foregroundColor(AppColors.mid.opacity(0.45))
+
+                    // Prompt word
+                    Text(viewModel.promptWord)
+                        .font(.custom("Georgia", size: 24))
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(AppColors.dark)
+
+                    // Divider
+                    Divider()
+                        .padding(.horizontal, 40)
+
+                    // Answer label
+                    Text(viewModel.answerLabel)
+                        .font(.system(size: 11, weight: .semibold))
+                        .tracking(1)
+                        .foregroundColor(AppColors.mid.opacity(0.45))
+
+                    // Text input
+                    TextField("Type your answer...", text: $viewModel.typingAnswer)
+                        .font(.system(size: 20, weight: .semibold))
+                        .multilineTextAlignment(.center)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .focused($isInputFocused)
+                        .disabled(viewModel.typingResult != nil)
+                        .onSubmit {
+                            if viewModel.typingResult == nil {
+                                viewModel.checkTypingAnswer()
+                            }
+                        }
+
+                    // Result feedback
+                    if let result = viewModel.typingResult {
+                        resultView(result)
+                            .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                    }
+                }
+                .padding(24)
+            }
+            .frame(minHeight: 290)
+
+            // Hint text
+            if viewModel.hintLevel > 0 && viewModel.typingResult == nil {
+                HStack(spacing: 4) {
+                    Text("Hint:")
+                        .font(.system(size: 14))
+                        .foregroundColor(AppColors.mid)
+                    Text(viewModel.hintText)
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundColor(.red)
+                        .tracking(2)
+                }
+                .padding(.top, 8)
+            }
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                isInputFocused = true
+            }
+        }
+    }
+
+    private var borderColor: Color {
+        switch viewModel.typingResult {
+        case .correct:
+            return AppColors.hgreen
+        case .incorrect:
+            return .red
+        case nil:
+            return AppColors.light
+        }
+    }
+
+    @ViewBuilder
+    private func resultView(_ result: DeckViewModel.TypingResult) -> some View {
+        switch result {
+        case .correct:
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle.fill")
+                Text("Correct!")
+            }
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundColor(AppColors.hgreen)
+
+        case .incorrect(let correct):
+            VStack(spacing: 4) {
+                HStack(spacing: 6) {
+                    Image(systemName: "xmark.circle.fill")
+                    Text("Incorrect")
+                }
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.red)
+
+                Text(correct)
+                    .font(.custom("Georgia", size: 18))
+                    .fontWeight(.bold)
+                    .foregroundColor(AppColors.dark)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 48))
+                .foregroundColor(AppColors.hgreen)
+            Text("No cards to review")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(AppColors.mid)
+        }
+        .frame(height: 290)
+    }
+}

--- a/ios/Geirfa/Views/UnitBarView.swift
+++ b/ios/Geirfa/Views/UnitBarView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct UnitBarView: View {
+    @ObservedObject var viewModel: DeckViewModel
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 7) {
+                    ForEach(viewModel.units, id: \.self) { unit in
+                        UnitButton(
+                            unit: unit,
+                            isActive: unit == viewModel.currentUnit && !viewModel.isReviewMode,
+                            mastery: viewModel.unitMasteryState(unit)
+                        ) {
+                            viewModel.selectUnit(unit)
+                        }
+                        .id(unit)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 4)
+            }
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    withAnimation {
+                        proxy.scrollTo(viewModel.currentUnit, anchor: .center)
+                    }
+                }
+            }
+            .onChange(of: viewModel.currentUnit) { newUnit in
+                withAnimation {
+                    proxy.scrollTo(newUnit, anchor: .center)
+                }
+            }
+        }
+    }
+}
+
+struct UnitButton: View {
+    let unit: String
+    let isActive: Bool
+    let mastery: UnitMastery
+    let action: () -> Void
+
+    var displayName: String {
+        if unit == "arholiad" { return "ARHOLIAD" }
+        return unit
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if mastery == .mastered {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 10))
+                }
+                Text(displayName)
+            }
+            .font(.system(size: 13, weight: .semibold))
+            .tracking(0.5)
+            .padding(.horizontal, 13)
+            .padding(.vertical, 6)
+            .background(isActive ? AppColors.dark : .white)
+            .foregroundColor(isActive ? .white : AppColors.mid)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .strokeBorder(
+                        isActive ? AppColors.dark :
+                        mastery == .mastered ? AppColors.hgreen :
+                        mastery == .partial ? AppColors.gold :
+                        AppColors.light,
+                        lineWidth: 1.5
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/ios/Geirfa/vocabulary.json
+++ b/ios/Geirfa/vocabulary.json
@@ -1,0 +1,6358 @@
+[
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "society (societies)",
+        "word_welsh": "cymdeithas(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "stream(s), creek(s)",
+        "word_welsh": "nant (nentydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "relative(s), relations(s)",
+        "word_welsh": "perthynas (perthnasau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "ward(s)",
+        "word_welsh": "ward(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "opening(s)",
+        "word_welsh": "agoriad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "conductor(s); leader(s)",
+        "word_welsh": "arweinydd (arweinyddion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "patient(s)",
+        "word_welsh": "claf (cleifion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "event(s)",
+        "word_welsh": "digwyddiad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "difference(s)",
+        "word_welsh": "gwahaniaeth(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "age(s)",
+        "word_welsh": "oedran(nau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "partner(s)",
+        "word_welsh": "partner(iaid)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "attention, remark(s)",
+        "word_welsh": "sylw(adau)"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "meddlesome, nosy",
+        "word_welsh": "busneslyd"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "lucky",
+        "word_welsh": "lwcus"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "to greet",
+        "word_welsh": "cyfarch"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "to introduce, to present",
+        "word_welsh": "cyflwyno"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "to sound",
+        "word_welsh": "swnio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "to join",
+        "word_welsh": "ymuno (â)"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "at the moment",
+        "word_welsh": "ar hyn o bryd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "lockdown",
+        "word_welsh": "cyfnod clo"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "by the way",
+        "word_welsh": "gyda llaw"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "1",
+        "word_english": "in my element",
+        "word_welsh": "wrth fy modd"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "brick(s)",
+        "word_welsh": "bricsen (brics)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "branch(es)",
+        "word_welsh": "cangen (canghennau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "orchestra(s)",
+        "word_welsh": "cerddorfa (cerddorfeydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "favour(s)",
+        "word_welsh": "cymwynas(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "rule(s)",
+        "word_welsh": "rheol(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "chance(s)",
+        "word_welsh": "siawns(iau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "order, arrangement(s)",
+        "word_welsh": "trefn(iadau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "Member(s) of the Senedd",
+        "word_welsh": "Aelod(au) o'r Senedd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "Member(s) of Parliament",
+        "word_welsh": "Aelod(au) Seneddol"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "dirt",
+        "word_welsh": "baw"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "lie(s)",
+        "word_welsh": "celwydd(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "summit(s)",
+        "word_welsh": "copa(on)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "wage(s), salary (salaries)",
+        "word_welsh": "cyflog(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "drug(s)",
+        "word_welsh": "cyffur(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "waste",
+        "word_welsh": "gwastraff"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "policy(-ies)",
+        "word_welsh": "polisi (polisïau)"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "unhappy",
+        "word_welsh": "anhapus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "certain",
+        "word_welsh": "sicr"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "stuck",
+        "word_welsh": "sownd"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "official",
+        "word_welsh": "swyddogol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "talented",
+        "word_welsh": "talentog"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to create",
+        "word_welsh": "creu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to make a noise",
+        "word_welsh": "cadw sŵn"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to cross",
+        "word_welsh": "croesi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to heat up",
+        "word_welsh": "cynhesu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to accept, to receive",
+        "word_welsh": "derbyn"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to drop",
+        "word_welsh": "gollwng"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to lie down",
+        "word_welsh": "gorwedd"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to insist",
+        "word_welsh": "mynnu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to jump",
+        "word_welsh": "neidio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "to grow dark",
+        "word_welsh": "tywyllu"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "awake",
+        "word_welsh": "ar ddihun"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "apart from",
+        "word_welsh": "heblaw am"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "supposed to",
+        "word_welsh": "i fod i"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "below",
+        "word_welsh": "isod"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "small change",
+        "word_welsh": "newid mân (arian)"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "in front of",
+        "word_welsh": "o flaen"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "small hours",
+        "word_welsh": "oriau mân"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "2",
+        "word_english": "lately, recently",
+        "word_welsh": "yn ddiweddar"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "series",
+        "word_welsh": "cyfres(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "article(s)",
+        "word_welsh": "erthygl(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "death(s)",
+        "word_welsh": "marwolaeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "situation(s)",
+        "word_welsh": "sefyllfa(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "collection(s)",
+        "word_welsh": "casgliad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "councillor(s)",
+        "word_welsh": "cynghorydd (cynghorwyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "sleet",
+        "word_welsh": "eirlaw"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "slope(s)",
+        "word_welsh": "llethr(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "plastic(s)",
+        "word_welsh": "plastig(au)"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "obvious, evident",
+        "word_welsh": "amlwg"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "nasty, unpleasant",
+        "word_welsh": "annifyr"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "tired",
+        "word_welsh": "blinedig"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "comfortable",
+        "word_welsh": "cyfforddus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "complicated",
+        "word_welsh": "cymhleth"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "entertaining",
+        "word_welsh": "difyr"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "depressed, depressing",
+        "word_welsh": "digalon"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "slippery",
+        "word_welsh": "llithrig"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "excellent",
+        "word_welsh": "rhagorol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "icy",
+        "word_welsh": "rhewllyd"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "steep",
+        "word_welsh": "serth"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "twisty, windy",
+        "word_welsh": "troellog"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "to recycle",
+        "word_welsh": "ailgylchu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "to save",
+        "word_welsh": "arbed"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "to argue (with)",
+        "word_welsh": "dadlau (â)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "to kill",
+        "word_welsh": "lladd"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "to slip",
+        "word_welsh": "llithro"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "to surprise; to be surprised",
+        "word_welsh": "synnu"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "to have your say",
+        "word_welsh": "dweud eich dweud"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "application form",
+        "word_welsh": "ffurflen gais"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "away from home",
+        "word_welsh": "oddi cartre"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "3",
+        "word_english": "mwy (quantity)",
+        "word_welsh": "rhagor"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "air, sky",
+        "word_welsh": "awyr"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "community (communities)",
+        "word_welsh": "cymuned(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "trip(s), excursion(s)",
+        "word_welsh": "gwibdaith (gwibdeithiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "fire engine(s)",
+        "word_welsh": "injan dân (injans tân)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "spade(s)",
+        "word_welsh": "rhaw(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "lifeboat(s)",
+        "word_welsh": "bad(au) achub"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "business(es)",
+        "word_welsh": "busnes(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "help",
+        "word_welsh": "cymorth"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "safety",
+        "word_welsh": "diogelwch"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "cold (tywydd)",
+        "word_welsh": "oerfel"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "owner(s)",
+        "word_welsh": "perchennog (perchnogion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "committee(s)",
+        "word_welsh": "pwyllgor(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "noise(s)",
+        "word_welsh": "sŵn (synau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "officer(s), official(s)",
+        "word_welsh": "swyddog(ion)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "to injure",
+        "word_welsh": "anafu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "to appeal (to)",
+        "word_welsh": "apelio (at)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "to push",
+        "word_welsh": "gwthio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "to dig",
+        "word_welsh": "palu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "to mention",
+        "word_welsh": "sôn"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "useful",
+        "word_welsh": "defnyddiol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "real",
+        "word_welsh": "go iawn"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "definite",
+        "word_welsh": "pendant"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "first aid",
+        "word_welsh": "cymorth cyntaf"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "health and safety",
+        "word_welsh": "iechyd a diogelwch"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "to give up",
+        "word_welsh": "rhoi'r gorau i"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "4",
+        "word_english": "fun and games",
+        "word_welsh": "sbort a sbri"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "education",
+        "word_welsh": "addysg"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "quarry (-ies)",
+        "word_welsh": "chwarel(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "tale(s)",
+        "word_welsh": "chwedl(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "shore(s), bank(s)",
+        "word_welsh": "glan(nau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "seagull(s)",
+        "word_welsh": "gwylan(od)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "slate(s)",
+        "word_welsh": "llechen (llechi)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "lightning",
+        "word_welsh": "mellten (mellt)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "cruise(s)",
+        "word_welsh": "mordaith (mordeithiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "gallery (-ies)",
+        "word_welsh": "oriel(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "standard(s)",
+        "word_welsh": "safon(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "torch(es)",
+        "word_welsh": "tortsh(ys)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "bone(s)",
+        "word_welsh": "asgwrn (esgyrn)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "judge(s), adjudicator(s)",
+        "word_welsh": "beirniad (beirniaid)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "cowshed(s)",
+        "word_welsh": "beudy (beudai)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "facility (-ies)",
+        "word_welsh": "cyfleuster(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "period(s) (amser)",
+        "word_welsh": "cyfnod(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "use",
+        "word_welsh": "defnydd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "guest(s)",
+        "word_welsh": "gwestai (gwesteion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "questionnaire(s)",
+        "word_welsh": "holiadur(on)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "location(s)",
+        "word_welsh": "lleoliad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "lake(s)",
+        "word_welsh": "llyn(noedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "mark(s)",
+        "word_welsh": "marc(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "pleasure(s)",
+        "word_welsh": "pleser(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "skeleton(s)",
+        "word_welsh": "sgerbwd (sgerbydau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "silk",
+        "word_welsh": "sidan"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "tourist(s)",
+        "word_welsh": "twrist(iaid)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "to cause",
+        "word_welsh": "achosi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "to wander, to roam",
+        "word_welsh": "crwydro"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "to hold (event)",
+        "word_welsh": "cynnal"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "to come to an end",
+        "word_welsh": "dod i ben"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "absent",
+        "word_welsh": "absennol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "huge",
+        "word_welsh": "anferth"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "pricey",
+        "word_welsh": "costus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "frightening",
+        "word_welsh": "dychrynllyd"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "folk",
+        "word_welsh": "gwerin"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "brand new",
+        "word_welsh": "newydd sbon"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "along",
+        "word_welsh": "ar hyd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "despite",
+        "word_welsh": "er gwaetha"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "bellyful (fed up)",
+        "word_welsh": "llond bola"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "5",
+        "word_english": "at least",
+        "word_welsh": "o leia"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "department(s)",
+        "word_welsh": "adran(nau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "envelope(s)",
+        "word_welsh": "amlen(ni)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "support",
+        "word_welsh": "cefnogaeth"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "audience(s); congregation(s)",
+        "word_welsh": "cynulleidfa(oedd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "loop(s); link(s); handle(s)",
+        "word_welsh": "dolen(ni)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "cathedral(s)",
+        "word_welsh": "eglwys gadeiriol (eglwysi cadeiriol)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "mood(s)",
+        "word_welsh": "hwyl(iau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "entrance(s)",
+        "word_welsh": "mynedfa (mynedfeydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "tourism",
+        "word_welsh": "twristiaeth"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "environment",
+        "word_welsh": "amgylchedd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "memory (-ies); recollection(s)",
+        "word_welsh": "atgof(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "dream(s)",
+        "word_welsh": "breuddwyd (ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "note, (written) record, (minutes)",
+        "word_welsh": "cofnod(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "friend(s)",
+        "word_welsh": "cyfaill (cyfeillion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "accountant(s)",
+        "word_welsh": "cyfrifydd (cyfrifwyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "boredom",
+        "word_welsh": "diflastod"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "industry (-ies)",
+        "word_welsh": "diwydiant (diwydiannau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "chemist(s)",
+        "word_welsh": "fferyllydd (fferyllwyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "fitness",
+        "word_welsh": "ffitrwydd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "laptop(s)",
+        "word_welsh": "gliniadur(on)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "hairdresser's",
+        "word_welsh": "siop trin gwallt"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "rest",
+        "word_welsh": "gorffwys"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "workplace(s)",
+        "word_welsh": "gweithle(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "note(s)",
+        "word_welsh": "nodyn (nodiadau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "injection(s)",
+        "word_welsh": "pigiad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "poster(s)",
+        "word_welsh": "poster(i)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "prescription(s)",
+        "word_welsh": "presgripsiwn (presgripsiynau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "scissor(s)",
+        "word_welsh": "siswrn (sisyrnau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "essay(s)",
+        "word_welsh": "traethawd (traethodau)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to blush",
+        "word_welsh": "cochi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to plan",
+        "word_welsh": "cynllunio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to escape",
+        "word_welsh": "dianc"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to succeed (in doing)",
+        "word_welsh": "llwyddo (i)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to market, marketing",
+        "word_welsh": "marchnata"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to last",
+        "word_welsh": "para"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to persuade",
+        "word_welsh": "perswadio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to trust",
+        "word_welsh": "ymddiried"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "useful",
+        "word_welsh": "defnyddiol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "safe",
+        "word_welsh": "diogel"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "away",
+        "word_welsh": "bant"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "dentures, false teeth",
+        "word_welsh": "dannedd gosod"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to come over",
+        "word_welsh": "dod draw"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "you poor thing",
+        "word_welsh": "druan â ti"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "to check, to look over",
+        "word_welsh": "edrych dros"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "including",
+        "word_welsh": "gan gynnwys"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "6",
+        "word_english": "in the evening",
+        "word_welsh": "gyda'r hwyr / gyda'r nos"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "junction(s)",
+        "word_welsh": "cyffordd (cyffyrdd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "talent(s)",
+        "word_welsh": "dawn (doniau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "witch(es)",
+        "word_welsh": "gwrach(od)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "bike lane",
+        "word_welsh": "lôn feicio"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "auction(s)",
+        "word_welsh": "ocsiwn (ocsiynau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "estuary (-ies)",
+        "word_welsh": "aber(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "artist(s)",
+        "word_welsh": "artist(iaid)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "sign(s)",
+        "word_welsh": "arwydd(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "calendar(s)",
+        "word_welsh": "calendr(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "speed camera",
+        "word_welsh": "camera cyflymder"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "giant(s)",
+        "word_welsh": "cawr (cewri)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "cricketer(s)",
+        "word_welsh": "cricedwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "direction(s), instruction(s)",
+        "word_welsh": "cyfarwyddyd (cyfarwyddiadau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "energy",
+        "word_welsh": "egni"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "election(s)",
+        "word_welsh": "etholiad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "accommodation",
+        "word_welsh": "llety"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "court(s)",
+        "word_welsh": "llys(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "country park",
+        "word_welsh": "parc gwledig"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "target(s)",
+        "word_welsh": "targed(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "subject(s); text(s)",
+        "word_welsh": "testun(au)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to adapt",
+        "word_welsh": "addasu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to kick",
+        "word_welsh": "cicio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to frighten",
+        "word_welsh": "codi ofn (ar)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to employ",
+        "word_welsh": "cyflogi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to contribute (to)",
+        "word_welsh": "cyfrannu (at)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to put; to set",
+        "word_welsh": "gosod"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to deny",
+        "word_welsh": "gwadu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to serve",
+        "word_welsh": "gweini"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to establish",
+        "word_welsh": "sefydlu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "to apologise (to)",
+        "word_welsh": "ymddiheuro (i)"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "dirty",
+        "word_welsh": "brwnt / budr"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "correct",
+        "word_welsh": "cywir"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "fierce",
+        "word_welsh": "ffyrnig"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "generous",
+        "word_welsh": "hael"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "successful",
+        "word_welsh": "llwyddiannus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "adventurous",
+        "word_welsh": "mentrus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "romantic",
+        "word_welsh": "rhamantus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "charming",
+        "word_welsh": "swynol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "in a hurry",
+        "word_welsh": "ar frys"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "front door",
+        "word_welsh": "drws ffrynt"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "better late than never",
+        "word_welsh": "gwell hwyr na hwyrach"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "if it weren't for...",
+        "word_welsh": "oni bai am..."
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "7",
+        "word_english": "...per cent",
+        "word_welsh": "...y cant"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "leek(s)",
+        "word_welsh": "cenhinen (cennin)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "crossroads",
+        "word_welsh": "croesffordd"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "law(s)",
+        "word_welsh": "cyfraith (cyfreithiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "earth",
+        "word_welsh": "daear"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "fact(s)",
+        "word_welsh": "ffaith (ffeithiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "frame(s)",
+        "word_welsh": "ffrâm (fframiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "operation(s)",
+        "word_welsh": "llawdriniaeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "heaven",
+        "word_welsh": "nefoedd"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "main road(s)",
+        "word_welsh": "priffordd (priffyrdd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "shock(s)",
+        "word_welsh": "sioc(iau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "tart(s)",
+        "word_welsh": "tarten(ni)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "ladder(s)",
+        "word_welsh": "ysgol(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "toe(s)",
+        "word_welsh": "bys troed (bysedd traed)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "excuse(s)",
+        "word_welsh": "esgus(odion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "vicar(s)",
+        "word_welsh": "ficer(iaid)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "horizon(s)",
+        "word_welsh": "gorwel(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "gravy",
+        "word_welsh": "grefi"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "Jesus",
+        "word_welsh": "Iesu"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "sunset",
+        "word_welsh": "machlud"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "distance",
+        "word_welsh": "pellter"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "spice(s)",
+        "word_welsh": "sbeis(ys)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "feeling(s)",
+        "word_welsh": "teimlad(au)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "to hold (on to)",
+        "word_welsh": "cydio (yn)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "to find",
+        "word_welsh": "dod o hyd i"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "to stink",
+        "word_welsh": "drewi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "to become quiet; to calm down",
+        "word_welsh": "tawelu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "to stretch",
+        "word_welsh": "ymestyn"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "to shake",
+        "word_welsh": "ysgwyd"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "unfortunate",
+        "word_welsh": "anffodus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "double",
+        "word_welsh": "dwbl"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "bilingual",
+        "word_welsh": "dwyieithog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "salty",
+        "word_welsh": "hallt"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "tight",
+        "word_welsh": "tyn(n)"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "outpatients department",
+        "word_welsh": "adran cleifion allanol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "to laugh at",
+        "word_welsh": "chwerthin am ben"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "although",
+        "word_welsh": "er"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "up until now",
+        "word_welsh": "hyd yn hyn"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "around",
+        "word_welsh": "o gwmpas"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "especially",
+        "word_welsh": "yn enwedig"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "8",
+        "word_english": "soon",
+        "word_welsh": "yn fuan"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "armchair(s)",
+        "word_welsh": "cadair freichiau (cadeiriau breichiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "bell(s)",
+        "word_welsh": "cloch (clychau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "cushion(s)",
+        "word_welsh": "clustog(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "effect(s)",
+        "word_welsh": "effaith (effeithiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "rainbow(s)",
+        "word_welsh": "enfys(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "bean(s)",
+        "word_welsh": "ffeuen (ffa)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "violin(s)",
+        "word_welsh": "ffidil (ffidlau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "smile(s)",
+        "word_welsh": "gwên (gwenau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "sunshine",
+        "word_welsh": "heulwen"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "sofa(s)",
+        "word_welsh": "soffa(s)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "fairy (fairies)",
+        "word_welsh": "tylwythen deg (tylwyth teg)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "decoration(s)",
+        "word_welsh": "addurn(iadau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "allergy (allergies)",
+        "word_welsh": "alergedd(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "smell(s)",
+        "word_welsh": "arogl(euon)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "step(s)",
+        "word_welsh": "cam(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "sleep",
+        "word_welsh": "cwsg"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "hallway(s)",
+        "word_welsh": "cyntedd(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "shortcoming(s); lack of",
+        "word_welsh": "diffyg(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "snowdrop(s)",
+        "word_welsh": "eirlys(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "youth",
+        "word_welsh": "ieuenctid"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "jungle(s)",
+        "word_welsh": "jyngl(s)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "fireplace(s)",
+        "word_welsh": "lle(oedd) tân"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "mask(s)",
+        "word_welsh": "mwgwd (mygydau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "respect",
+        "word_welsh": "parch"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "warning(s)",
+        "word_welsh": "rhybudd(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "shape(s)",
+        "word_welsh": "siâp (siapiau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "response(s)",
+        "word_welsh": "ymateb(ion)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to reopen",
+        "word_welsh": "ailagor"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to breathe",
+        "word_welsh": "anadlu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to smell",
+        "word_welsh": "arogli"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to taste",
+        "word_welsh": "blasu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to bully",
+        "word_welsh": "bwlio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to exchange",
+        "word_welsh": "cyfnewid"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to weed",
+        "word_welsh": "chwynnu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to squeeze, to squash",
+        "word_welsh": "gwasgu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to waste",
+        "word_welsh": "gwastraffu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to venture, to dare",
+        "word_welsh": "mentro"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to graze; to browse",
+        "word_welsh": "pori"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to prance, to gambol",
+        "word_welsh": "prancio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to rent",
+        "word_welsh": "rhentu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to realise",
+        "word_welsh": "sylweddoli"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "untidy",
+        "word_welsh": "anniben"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "keen",
+        "word_welsh": "awyddus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "courteous, polite",
+        "word_welsh": "cwrtais"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "deep",
+        "word_welsh": "dwfn"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "convenient",
+        "word_welsh": "hwylus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "luxurious",
+        "word_welsh": "moethus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "nervous",
+        "word_welsh": "nerfus"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "locked",
+        "word_welsh": "ar glo"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to knock the door",
+        "word_welsh": "curo'r drws"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "to reminisce",
+        "word_welsh": "hel atgofion"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "hen bobl",
+        "word_welsh": "henoed"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "ground floor",
+        "word_welsh": "llawr gwaelod"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "a dweud y gwir",
+        "word_welsh": "mewn gwirionedd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "within",
+        "word_welsh": "o fewn"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "far end; long run",
+        "word_welsh": "pen draw"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "rhywbeth yn bod",
+        "word_welsh": "rhywbeth o'i le"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "semi-detached house",
+        "word_welsh": "tŷ pâr/tŷ semi"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "9",
+        "word_english": "completely, exactly",
+        "word_welsh": "yn hollol"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "exhibition(s)",
+        "word_welsh": "arddangosfa (arddangosfeydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "stone(s)",
+        "word_welsh": "carreg (cerrig)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "memorial(s)",
+        "word_welsh": "cofeb(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "bog(s)",
+        "word_welsh": "cors(ydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "craft(s)",
+        "word_welsh": "crefft(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "grape(s)",
+        "word_welsh": "grawnwinen (grawnwin)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "government(s)",
+        "word_welsh": "llywodraeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "maid(s)",
+        "word_welsh": "morwyn (morynion)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "graveyard(s), cemetery(-ies)",
+        "word_welsh": "mynwent(ydd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "disease(s)",
+        "word_welsh": "afiechyd(on)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "blame; fault(s)",
+        "word_welsh": "bai (beiau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "lock(s)",
+        "word_welsh": "clo(eon)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "cliff(s)",
+        "word_welsh": "clogwyn(i)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "memory",
+        "word_welsh": "cof"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "wealth",
+        "word_welsh": "cyfoeth"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "shadow(s); shade(s)",
+        "word_welsh": "cysgod(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "use",
+        "word_welsh": "defnydd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "economy (economies)",
+        "word_welsh": "economi (economïau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "twin(s)",
+        "word_welsh": "gefell (gefeilliaid)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "activity(-ies)",
+        "word_welsh": "gweithgaredd(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "wool",
+        "word_welsh": "gwlân"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "training",
+        "word_welsh": "hyfforddiant"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "success(es)",
+        "word_welsh": "llwyddiant (llwyddiannau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "stage(s)",
+        "word_welsh": "llwyfan(nau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "childhood",
+        "word_welsh": "plentyndod"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "purpose(s)",
+        "word_welsh": "pwrpas(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "stance(s), viewpoint(s)",
+        "word_welsh": "safbwynt(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "love",
+        "word_welsh": "serch"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "roof(s)",
+        "word_welsh": "to(eon)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to remind",
+        "word_welsh": "atgoffa"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to communicate",
+        "word_welsh": "cyfathrebu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to suffer",
+        "word_welsh": "dioddef"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to mean; to edit",
+        "word_welsh": "golygu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to graduate",
+        "word_welsh": "graddio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to knit",
+        "word_welsh": "gwau"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to snorkel",
+        "word_welsh": "snorclo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to raft",
+        "word_welsh": "rafftio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to prevent",
+        "word_welsh": "rhwystro"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "to melt",
+        "word_welsh": "toddi"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "loving",
+        "word_welsh": "cariadus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "creative",
+        "word_welsh": "creadigol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "common; general",
+        "word_welsh": "cyffredin"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "social; sociable",
+        "word_welsh": "cymdeithasol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "serious",
+        "word_welsh": "difrifol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "detailed",
+        "word_welsh": "manwl"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "soft",
+        "word_welsh": "meddal"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "professional",
+        "word_welsh": "proffesiynol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "talkative",
+        "word_welsh": "siaradus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "sour",
+        "word_welsh": "sur"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "thick",
+        "word_welsh": "trwchus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "tourist",
+        "word_welsh": "twristaidd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "on behalf of",
+        "word_welsh": "ar ran"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "fresh air",
+        "word_welsh": "awyr iach"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "around",
+        "word_welsh": "o amgylch"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "named, called",
+        "word_welsh": "o’r enw"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "the majority",
+        "word_welsh": "y rhan fwya"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "10",
+        "word_english": "eisiau",
+        "word_welsh": "isio"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "period(s) of time",
+        "word_welsh": "adeg(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "agriculture",
+        "word_welsh": "amaethyddiaeth"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "easy chair",
+        "word_welsh": "cadair esmwyth"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "understanding",
+        "word_welsh": "dealltwriaeth"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "debt(s)",
+        "word_welsh": "dyled(ion)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "flame(s)",
+        "word_welsh": "fflam(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "lip(s)",
+        "word_welsh": "gwefus(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "politics",
+        "word_welsh": "gwleidyddiaeth"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "shelter(s)",
+        "word_welsh": "lloches(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "medication(s)",
+        "word_welsh": "meddyginiaeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "rope(s)",
+        "word_welsh": "rhaff(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "injury (-ies)",
+        "word_welsh": "anaf(iadau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "cap(s)",
+        "word_welsh": "cap(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "cradle(s), cot(s)",
+        "word_welsh": "crud(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "knot(s)",
+        "word_welsh": "cwlwm (clymau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "tear(s)",
+        "word_welsh": "deigryn (dagrau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "mirror(s)",
+        "word_welsh": "drych(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "extension(s)",
+        "word_welsh": "estyniad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "refugee(s)",
+        "word_welsh": "ffoadur(iaid)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "fireplace(s)",
+        "word_welsh": "lle tân (llefydd tân)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "leather",
+        "word_welsh": "lledr"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "spokesperson (spokespeople)",
+        "word_welsh": "llefarydd (llefarwyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "flood(s)",
+        "word_welsh": "llif(ogydd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "metal(s)",
+        "word_welsh": "metel(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "smoke",
+        "word_welsh": "mwg"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "pattern(s)",
+        "word_welsh": "patrwm (patrymau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "danger(s)",
+        "word_welsh": "perygl(on)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "fisherman (-men)",
+        "word_welsh": "pysgotwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "cyclist(s)",
+        "word_welsh": "seiclwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "square(s)",
+        "word_welsh": "sgwâr (sgwariau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "land; ground(s)",
+        "word_welsh": "tir(oedd)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to recite, to relate",
+        "word_welsh": "adrodd"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to arrest",
+        "word_welsh": "arestio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to print",
+        "word_welsh": "argraffu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to hit",
+        "word_welsh": "bwrw"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to tie; to knot",
+        "word_welsh": "clymu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to disappear",
+        "word_welsh": "diflannu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to destroy",
+        "word_welsh": "dinistrio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to name",
+        "word_welsh": "enwi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to overflow",
+        "word_welsh": "gorlifo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to swallow",
+        "word_welsh": "llyncu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to pause; to delay",
+        "word_welsh": "oedi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to bend, to fold",
+        "word_welsh": "plygu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to protest",
+        "word_welsh": "protestio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to record",
+        "word_welsh": "recordio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to whisper",
+        "word_welsh": "sibrwd"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to rock; to shake",
+        "word_welsh": "siglo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to store",
+        "word_welsh": "storio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "to resign",
+        "word_welsh": "ymddiswyddo"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "agricultural",
+        "word_welsh": "amaethyddol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "round",
+        "word_welsh": "crwn"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "impatient",
+        "word_welsh": "diamynedd"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "restful; smooth",
+        "word_welsh": "esmwyth"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "oval",
+        "word_welsh": "hirgrwn"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "rectangular",
+        "word_welsh": "petryal"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "spotty",
+        "word_welsh": "smotiog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "striped",
+        "word_welsh": "streipiog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "thick, dense",
+        "word_welsh": "trwchus"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "long time ago",
+        "word_welsh": "amser maith yn ôl"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "at the time",
+        "word_welsh": "ar y pryd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "Olympic Games",
+        "word_welsh": "Gemau Olympaidd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "that",
+        "word_welsh": "hynny"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "from bad to worse",
+        "word_welsh": "o ddrwg i waeth"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "achos",
+        "word_welsh": "oherwydd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "First/Prime Minister",
+        "word_welsh": "Prif Weinidog"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "within (amser)",
+        "word_welsh": "ymhen"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "as well as, in addition to",
+        "word_welsh": "yn ogystal â"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "11",
+        "word_english": "these",
+        "word_welsh": "y rhain"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "exit(s)",
+        "word_welsh": "allanfa (allanfeydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "area(s), region(s)",
+        "word_welsh": "bro(ydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "breast(s), chest(s)",
+        "word_welsh": "bron(nau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "loss(es)",
+        "word_welsh": "colled(ion)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "secret(s)",
+        "word_welsh": "cyfrinach(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "desk(s)",
+        "word_welsh": "desg(iau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "birth(s)",
+        "word_welsh": "genedigaeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "great-grandmother",
+        "word_welsh": "hen fam-gu"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "personality (-ies)",
+        "word_welsh": "personoliaeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "political party (-ies)",
+        "word_welsh": "plaid (pleidiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "row(s)",
+        "word_welsh": "rhes(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "net(s)",
+        "word_welsh": "rhwyd(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "voucher(s)",
+        "word_welsh": "taleb(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "female harpist(s)",
+        "word_welsh": "telynores(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "crowd(s)",
+        "word_welsh": "torf(eydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "treatment(s)",
+        "word_welsh": "triniaeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "crowd(s)",
+        "word_welsh": "tyrfa(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "artist(s)",
+        "word_welsh": "arlunydd (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "inspector(s)",
+        "word_welsh": "arolygydd (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "taste(s)",
+        "word_welsh": "blas(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "box(es)",
+        "word_welsh": "blwch (blychau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "hill(s)",
+        "word_welsh": "bryn(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "mistake(s)",
+        "word_welsh": "camgymeriad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "cancer(s)",
+        "word_welsh": "canser(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "body (bodies)",
+        "word_welsh": "corff (cyrff)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "crew(s)",
+        "word_welsh": "criw(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "strength(s)",
+        "word_welsh": "cryfder(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "total(s)",
+        "word_welsh": "cyfanswm (cyfansymiau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "drawing(s)",
+        "word_welsh": "darlun(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "damage",
+        "word_welsh": "difrod"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "culture(s)",
+        "word_welsh": "diwylliant (diwylliannau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "piece(s) of furniture",
+        "word_welsh": "dodrefnyn (dodrefn)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "great-grand father",
+        "word_welsh": "hen dad-cu"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "lad(s), youth(s)",
+        "word_welsh": "llanc(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "place(s)",
+        "word_welsh": "man(nau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "movement(s), organisation(s)",
+        "word_welsh": "mudiad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "package(s)",
+        "word_welsh": "pecyn(nau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "position(s), site(s)",
+        "word_welsh": "safle(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "institution(s), establishment(s)",
+        "word_welsh": "sefydliad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "male harpist(s)",
+        "word_welsh": "telynor(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "sadness",
+        "word_welsh": "tristwch"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "temperature",
+        "word_welsh": "tymheredd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "darkness",
+        "word_welsh": "tywyllwch"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "individual(s)",
+        "word_welsh": "unigolyn (unigolion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "research",
+        "word_welsh": "ymchwil"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to exhibit",
+        "word_welsh": "arddangos"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to imprison",
+        "word_welsh": "carcharu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to welcome",
+        "word_welsh": "croesawu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to laze",
+        "word_welsh": "diogi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to say goodbye (to)",
+        "word_welsh": "ffarwelio (â)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to claim",
+        "word_welsh": "hawlio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to spread; to widen",
+        "word_welsh": "lledu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to reduce",
+        "word_welsh": "lleihau"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to continue",
+        "word_welsh": "parhau"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to plant",
+        "word_welsh": "plannu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to rush",
+        "word_welsh": "rhuthro"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to warn",
+        "word_welsh": "rhybuddio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to shoot",
+        "word_welsh": "saethu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to heat (up)",
+        "word_welsh": "twymo"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "second-hand",
+        "word_welsh": "ail-law"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "bach",
+        "word_welsh": "bychan"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "lively",
+        "word_welsh": "bywiog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "equal",
+        "word_welsh": "cyfartal"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "innocent, not guilty",
+        "word_welsh": "dieuog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "electronic",
+        "word_welsh": "electronig"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "guilty",
+        "word_welsh": "euog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "leisurely",
+        "word_welsh": "hamddenol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "full of fun",
+        "word_welsh": "hwyliog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "oral",
+        "word_welsh": "llafar"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "physical education",
+        "word_welsh": "addysg gorfforol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "mwynhau",
+        "word_welsh": "cael blas ar"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "to find, to discover",
+        "word_welsh": "cael hyd i"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "hundredth",
+        "word_welsh": "canfed"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "breast cancer",
+        "word_welsh": "canser y fron"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "draw",
+        "word_welsh": "gêm gyfartal"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "drizzle",
+        "word_welsh": "glaw mân"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "exactly",
+        "word_welsh": "i’r dim"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "12",
+        "word_english": "from now on",
+        "word_welsh": "o hyn ymlaen"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "exit(s)",
+        "word_welsh": "allanfa (allanfeydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "basket(s)",
+        "word_welsh": "basged(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "gravestone(s)",
+        "word_welsh": "carreg fedd (cerrig beddau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "nut(s)",
+        "word_welsh": "cneuen (cnau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "coconut(s)",
+        "word_welsh": "cneuen goco (cnau coco)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "number(s), quantity(-ies)",
+        "word_welsh": "nifer(oedd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "racket(s)",
+        "word_welsh": "raced(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "dialect(s)",
+        "word_welsh": "tafodiaith (tafodieithoedd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "state(s)",
+        "word_welsh": "talaith (taleithiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "handwriting",
+        "word_welsh": "ysgrifen"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "authority (-ies)",
+        "word_welsh": "awdurdod(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "prison(s)",
+        "word_welsh": "carchar(dai)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "supporter(s)",
+        "word_welsh": "cefnogwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "caretaker(s); carer(s)",
+        "word_welsh": "gofalwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "grammar",
+        "word_welsh": "gramadeg"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "location(s)",
+        "word_welsh": "lleoliad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "enjoyment",
+        "word_welsh": "mwynhad"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "prairie(s)",
+        "word_welsh": "paith (peithiau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "war(s)",
+        "word_welsh": "rhyfel(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "arrangement(s)",
+        "word_welsh": "trefniad(-au)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "to chair",
+        "word_welsh": "cadeirio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "to get wet",
+        "word_welsh": "gwlychu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "to age",
+        "word_welsh": "heneiddio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "to wrap",
+        "word_welsh": "lapio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "to treat",
+        "word_welsh": "trin"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "open",
+        "word_welsh": "agored"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "necessary",
+        "word_welsh": "angenrheidiol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "annual",
+        "word_welsh": "blynyddol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "clever",
+        "word_welsh": "clyfar"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "responsible",
+        "word_welsh": "cyfrifol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "intelligent",
+        "word_welsh": "deallus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "capable, brainy",
+        "word_welsh": "galluog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "hardworking",
+        "word_welsh": "gweithgar"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "likeable",
+        "word_welsh": "hoffus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "private",
+        "word_welsh": "preifat"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "stable, fixed, unchanging",
+        "word_welsh": "sefydlog"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "to make do, to answer the purpose",
+        "word_welsh": "gwneud y tro"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "personal details",
+        "word_welsh": "manylion personol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "13",
+        "word_english": "from afar",
+        "word_welsh": "o bell"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "attitude(s)",
+        "word_welsh": "agwedd(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "cage(s)",
+        "word_welsh": "caets(ys) / cawell (cewyll)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "poem(s)",
+        "word_welsh": "cerdd(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "complaint(s)",
+        "word_welsh": "cwyn(ion)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "level(s)",
+        "word_welsh": "lefel(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "nest(s)",
+        "word_welsh": "nyth(od)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "pipe(s)",
+        "word_welsh": "pibell(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "traffic jam(s)",
+        "word_welsh": "tagfa (tagfeydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "thunder",
+        "word_welsh": "taran(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "patience",
+        "word_welsh": "amynedd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "athletics",
+        "word_welsh": "athletau"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "chat",
+        "word_welsh": "clonc"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "cotton",
+        "word_welsh": "cotwm"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "counter(s)",
+        "word_welsh": "cownter(i)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "contact",
+        "word_welsh": "cyswllt"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "diet",
+        "word_welsh": "deiet"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "unemployment",
+        "word_welsh": "diweithdra"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "climber(s)",
+        "word_welsh": "dringwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "care",
+        "word_welsh": "gofal"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "confidence",
+        "word_welsh": "hyder"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "burglary (burglaries)",
+        "word_welsh": "lladrad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "thief (thieves)",
+        "word_welsh": "lleidr (lladron)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "plural(s)",
+        "word_welsh": "lluosog(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "load(s)",
+        "word_welsh": "llwyth(i)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "mud",
+        "word_welsh": "mwd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "profession(s)",
+        "word_welsh": "proffesiwn (proffesiynau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "runner(s)",
+        "word_welsh": "rhedwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "stuffing",
+        "word_welsh": "stwffin"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "drought; dryness",
+        "word_welsh": "sychder"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "track(s)",
+        "word_welsh": "trac(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "witness(es)",
+        "word_welsh": "tyst(ion)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to repeat",
+        "word_welsh": "ailadrodd"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to appeal",
+        "word_welsh": "apelio (at)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to suggest",
+        "word_welsh": "awgrymu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to transport",
+        "word_welsh": "cludo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to crown",
+        "word_welsh": "coroni"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to itch",
+        "word_welsh": "cosi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to mix (with)",
+        "word_welsh": "cymysgu (â)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to deal (with)",
+        "word_welsh": "delio (â)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to press; to weigh",
+        "word_welsh": "pwyso"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to race",
+        "word_welsh": "rasio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to apply (for)",
+        "word_welsh": "ymgeisio (am)"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "intense; intensive",
+        "word_welsh": "dwys"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "wild",
+        "word_welsh": "gwyllt"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "all-important",
+        "word_welsh": "hollbwysig"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "muddy",
+        "word_welsh": "mwdlyd"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "odd",
+        "word_welsh": "od"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "rare, scarce",
+        "word_welsh": "prin"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "experienced",
+        "word_welsh": "profiadol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "single",
+        "word_welsh": "sengl"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "thirsty",
+        "word_welsh": "sychedig"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "The Brecon Beacons",
+        "word_welsh": "Bannau Brycheiniog"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "over; overleaf",
+        "word_welsh": "drosodd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "to make a mess of",
+        "word_welsh": "gwneud cawl o"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "chit-chat",
+        "word_welsh": "mân siarad"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "seriously",
+        "word_welsh": "o ddifri"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "popeth",
+        "word_welsh": "pob dim"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "foster parent(s)",
+        "word_welsh": "rhiant (rhieni) maeth"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "cross country",
+        "word_welsh": "traws gwlad"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "hard of hearing",
+        "word_welsh": "trwm ei glyw/chlyw"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "exhausted",
+        "word_welsh": "wedi blino’n lân"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "mainly",
+        "word_welsh": "yn bennaf"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "alive and kicking",
+        "word_welsh": "yn fyw ac yn iach"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "14",
+        "word_english": "immediately",
+        "word_welsh": "yn syth bin"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "scar(s)",
+        "word_welsh": "craith (creithiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "border(s)",
+        "word_welsh": "ffin(iau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "stick(s)",
+        "word_welsh": "ffon (ffyn)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "printing press(es)",
+        "word_welsh": "gwasg (gweisg)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "yard(s)",
+        "word_welsh": "iard(iau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "rocket(s)",
+        "word_welsh": "roced(i)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "strike(s)",
+        "word_welsh": "streic(iau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "task(s)",
+        "word_welsh": "tasg(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "China",
+        "word_welsh": "Tsieina"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "temperature",
+        "word_welsh": "tymheredd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "result(s)",
+        "word_welsh": "canlyniad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "cloth(s), rag(s)",
+        "word_welsh": "clwtyn (clytiau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "hay hut",
+        "word_welsh": "cwt gwair"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "hen coop",
+        "word_welsh": "cwt ieir"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "drill(s)",
+        "word_welsh": "dril(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "steel",
+        "word_welsh": "dur"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "virus(es)",
+        "word_welsh": "feirws (feirysau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "gum",
+        "word_welsh": "gwm"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "dust",
+        "word_welsh": "llwch"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "decision(s)",
+        "word_welsh": "penderfyniad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "headline(s)",
+        "word_welsh": "pennawd (penawdau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "earth, soil",
+        "word_welsh": "pridd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "sauce(s)",
+        "word_welsh": "saws(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "style",
+        "word_welsh": "steil"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "payment(s)",
+        "word_welsh": "tâl (taliadau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "tape(s)",
+        "word_welsh": "tâp (tapiau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "sty (sties)",
+        "word_welsh": "twlc (tylciau)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "to renew, to refurbish",
+        "word_welsh": "adnewyddu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "to promise",
+        "word_welsh": "addo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "gorffen",
+        "word_welsh": "cwblhau"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "to flow",
+        "word_welsh": "llifo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "to measure",
+        "word_welsh": "mesur"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "to slink, to sneak, to sidle",
+        "word_welsh": "sleifio"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "disgusting; sickly",
+        "word_welsh": "afiach"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "a few",
+        "word_welsh": "ambell"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "unusual",
+        "word_welsh": "anarferol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "unlucky",
+        "word_welsh": "anlwcus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "usual",
+        "word_welsh": "arferol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "narrow",
+        "word_welsh": "cul"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "strange",
+        "word_welsh": "dieithr"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "daily",
+        "word_welsh": "dyddiol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "flat",
+        "word_welsh": "gwastad"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "healthy (bwyd)",
+        "word_welsh": "iachus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "wide",
+        "word_welsh": "llydan"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "severe",
+        "word_welsh": "llym"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "enjoyable",
+        "word_welsh": "pleserus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "pure",
+        "word_welsh": "pur"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "sudden",
+        "word_welsh": "sydyn"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "weekly",
+        "word_welsh": "wythnosol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "to keep an eye on; to keep track of",
+        "word_welsh": "cadw golwg ar"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "maintenance",
+        "word_welsh": "cynnal a chadw"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "under pressure",
+        "word_welsh": "dan bwysau"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "closing date",
+        "word_welsh": "dyddiad cau"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "chewing gum",
+        "word_welsh": "gwm cnoi"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "exactly! perfect!",
+        "word_welsh": "i’r dim!"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "15",
+        "word_english": "per head",
+        "word_welsh": "y pen"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "Argentina",
+        "word_welsh": "Yr Ariannin"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "masters degree",
+        "word_welsh": "gradd meistr"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "literature",
+        "word_welsh": "llenyddiaeth"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "medal(s)",
+        "word_welsh": "medal(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "venture(s); initiative(s)",
+        "word_welsh": "menter (mentrau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "championship(s)",
+        "word_welsh": "pencampwriaeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "transport",
+        "word_welsh": "trafnidiaeth"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "habit(s)",
+        "word_welsh": "arfer(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "review(s); survey(s)",
+        "word_welsh": "arolwg (arolygon)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "tiredness",
+        "word_welsh": "blinder"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "bulb(s)",
+        "word_welsh": "bylb(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "middle part, region (mewn gwlad)",
+        "word_welsh": "canolbarth"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "chemical(s)",
+        "word_welsh": "cemegyn (cemegau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "partner, companion",
+        "word_welsh": "cymar"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "plan(s); design(s)",
+        "word_welsh": "cynllun(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "silence",
+        "word_welsh": "distawrwydd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "valley(s)",
+        "word_welsh": "dyffryn(noedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "explanations(s)",
+        "word_welsh": "esboniad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "space",
+        "word_welsh": "gofod"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "lighthouse(s)",
+        "word_welsh": "goleudy (goleudai)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "happiness",
+        "word_welsh": "hapusrwydd"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "lollypop(s)",
+        "word_welsh": "lolipop(s)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "obsession(s)",
+        "word_welsh": "obsesiwn (obsesiynau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "pavement(s)",
+        "word_welsh": "palmant (palmentydd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "striker(s)",
+        "word_welsh": "streiciwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "cut(s)",
+        "word_welsh": "toriad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "mutation(s)",
+        "word_welsh": "treiglad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "union(s)",
+        "word_welsh": "undeb(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "energy",
+        "word_welsh": "ynni"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "to encourage",
+        "word_welsh": "annog"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "to explain",
+        "word_welsh": "egluro"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "to launch",
+        "word_welsh": "lansio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "to fall (gogledd Cymru)",
+        "word_welsh": "syrthio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "to mutate",
+        "word_welsh": "treiglo"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "well-known",
+        "word_welsh": "adnabyddus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "grand",
+        "word_welsh": "crand"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "contemporary",
+        "word_welsh": "cyfoes"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "public",
+        "word_welsh": "cyhoeddus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "ddim yn siarad Cymraeg",
+        "word_welsh": "di-Gymraeg"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "countless",
+        "word_welsh": "di-ri(f)"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "evident; clear",
+        "word_welsh": "eglur"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "vegan",
+        "word_welsh": "figan"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "vegetarian",
+        "word_welsh": "llysieuol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "etc.",
+        "word_welsh": "ac yn y blaen"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "spoken; orally",
+        "word_welsh": "ar lafar"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "in the lead",
+        "word_welsh": "ar y blaen"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "downstairs",
+        "word_welsh": "lawr llawr"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "from (on); off; down from",
+        "word_welsh": "oddi ar"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "common sense",
+        "word_welsh": "synnwyr cyffredin"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "one-day",
+        "word_welsh": "undydd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "above",
+        "word_welsh": "uwchben"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "against",
+        "word_welsh": "yn erbyn"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "16",
+        "word_english": "the colony (Patagonia)",
+        "word_welsh": "y Wladfa"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "wing(s)",
+        "word_welsh": "adain (adenydd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "variety (-ies); variation(s)",
+        "word_welsh": "amrywiaeth(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "lecture(s)",
+        "word_welsh": "darlith(oedd)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "blackthorn",
+        "word_welsh": "draenen ddu"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "lovespoon(s)",
+        "word_welsh": "llwy garu (llwyau caru)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "forehead(s)",
+        "word_welsh": "talcen(ni)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "licence(s)",
+        "word_welsh": "trwydded(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "thumb(s)",
+        "word_welsh": "bawd (bodiau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "kangaroo(s)",
+        "word_welsh": "cangarŵ(od)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "vehicle(s)",
+        "word_welsh": "cerbyd(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "account(s)",
+        "word_welsh": "cyfrif(on)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "circle(s)",
+        "word_welsh": "cylch(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "historian(s)",
+        "word_welsh": "hanesydd (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "mayor(s)",
+        "word_welsh": "maer (meiri)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "beauty",
+        "word_welsh": "prydferthwch"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "power(s)",
+        "word_welsh": "pŵer (pwerau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "sex(es)",
+        "word_welsh": "rhyw(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "symbol(s)",
+        "word_welsh": "symbol(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "type(s)",
+        "word_welsh": "teip(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "tradition(s)",
+        "word_welsh": "traddodiad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "retirement(s)",
+        "word_welsh": "ymddeoliad(au)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to time",
+        "word_welsh": "amseru"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to dream",
+        "word_welsh": "breuddwydio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to intend",
+        "word_welsh": "bwriadu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to chatter",
+        "word_welsh": "clebran"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to comb",
+        "word_welsh": "cribo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to film",
+        "word_welsh": "ffilmio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to twin (with)",
+        "word_welsh": "gefeillio (â)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to fear",
+        "word_welsh": "ofni"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to count",
+        "word_welsh": "rhifo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to release",
+        "word_welsh": "rhyddhau"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "historical",
+        "word_welsh": "hanesyddol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "on the whole",
+        "word_welsh": "ar y cyfan"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "leap year",
+        "word_welsh": "blwyddyn naid"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "at that time",
+        "word_welsh": "bryd hynny"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "finger buffet",
+        "word_welsh": "bwffe bys a bawd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "May Day",
+        "word_welsh": "Calan Mai"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "to clap, to applaud",
+        "word_welsh": "curo dwylo"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "playgroup",
+        "word_welsh": "cylch chwarae"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "Valentine’s Day",
+        "word_welsh": "Dydd Ffolant"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "even so",
+        "word_welsh": "eto i gyd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "tides; ebb and flow",
+        "word_welsh": "llanw a thrai"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "beforehand",
+        "word_welsh": "ymlaen llaw"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "17",
+        "word_english": "the Middle Ages",
+        "word_welsh": "yr Oesoedd Canol"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "order(s)",
+        "word_welsh": "archeb(ion)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "cross(es)",
+        "word_welsh": "croes(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "spoonful(s)",
+        "word_welsh": "llwyaid (llwyeidiau)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "gwraig o Brydain",
+        "word_welsh": "Prydeinwraig"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "effort(s)",
+        "word_welsh": "ymdrech(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "bat(s)",
+        "word_welsh": "bat(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "bomb(s)",
+        "word_welsh": "bom(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "catalogue(s)",
+        "word_welsh": "catalog(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "foam",
+        "word_welsh": "ewyn"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "reduction(s)",
+        "word_welsh": "gostyngiad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "old age",
+        "word_welsh": "henaint"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "strength",
+        "word_welsh": "nerth"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "pobl o Brydain",
+        "word_welsh": "Prydeiniwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "storehouse(s)",
+        "word_welsh": "stordy (stordai)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "lead",
+        "word_welsh": "tennyn"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "top(s)",
+        "word_welsh": "top(iau)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to advise",
+        "word_welsh": "cynghori"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to explode",
+        "word_welsh": "ffrwydro"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to avoid",
+        "word_welsh": "osgoi"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to point",
+        "word_welsh": "pwyntio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to roast",
+        "word_welsh": "rhostio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to look (Gogledd)",
+        "word_welsh": "sbio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to stare (at), to gaze (at)",
+        "word_welsh": "syllu (ar)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to splutter; to choke",
+        "word_welsh": "tagu"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to fight",
+        "word_welsh": "ymladd"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "fortunate",
+        "word_welsh": "ffodus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "native",
+        "word_welsh": "genedigol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "punctual, prompt",
+        "word_welsh": "prydlon"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "belly button",
+        "word_welsh": "botwm bol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "weightlifting",
+        "word_welsh": "codi pwysau"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to lose hold (of)",
+        "word_welsh": "colli gafael (ar)"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "food craving",
+        "word_welsh": "chwant bwyd"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "full to the rafters",
+        "word_welsh": "dan ei sang"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "set book",
+        "word_welsh": "llyfr gosod"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "from time to time",
+        "word_welsh": "o dro i dro"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "to gaze in amazement",
+        "word_welsh": "syllu’n syn"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "18",
+        "word_english": "amongst",
+        "word_welsh": "ymhlith"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "merch o Iwerddon",
+        "word_welsh": "Gwyddeles"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "hero(es)",
+        "word_welsh": "arwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "judge(s)",
+        "word_welsh": "barnwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "make-up",
+        "word_welsh": "colur"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "copy (-ies)",
+        "word_welsh": "copi (copïau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "excitement",
+        "word_welsh": "cyffro"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "dyn (pobl) o Iwerddon",
+        "word_welsh": "Gwyddel(od)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "mural(s)",
+        "word_welsh": "murlun(iau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "heath(s), moor(s)",
+        "word_welsh": "rhos(ydd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "Romans",
+        "word_welsh": "Rhufeiniaid"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "obstacle(s)",
+        "word_welsh": "rhwystr(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "treasure(s)",
+        "word_welsh": "trysor(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "ghost(s), spirit(s)",
+        "word_welsh": "ysbryd(ion)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "to beat",
+        "word_welsh": "curo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "to affect",
+        "word_welsh": "effeithio (ar)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "to staff",
+        "word_welsh": "staffio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "to unite (with)",
+        "word_welsh": "uno (â)"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "fearful; frightened",
+        "word_welsh": "ofnus"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "British",
+        "word_welsh": "Prydeinig"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "the length and breadth",
+        "word_welsh": "ar hyd a lled"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "for rent",
+        "word_welsh": "ar osod"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "to get rid of",
+        "word_welsh": "cael gwared ar"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "to wave (to)",
+        "word_welsh": "codi llaw (ar)"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "to keep at it, to persevere",
+        "word_welsh": "dal ati"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "19",
+        "word_english": "apparently",
+        "word_welsh": "yn ôl pob sôn"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "disadvantage(s)",
+        "word_welsh": "anfantais (anfanteision)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "example(s)",
+        "word_welsh": "esiampl(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "gymnastics",
+        "word_welsh": "gymnasteg"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "advantage(s)",
+        "word_welsh": "mantais (manteision)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "process(es)",
+        "word_welsh": "proses(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "circus(es)",
+        "word_welsh": "syrcas(au)"
+    },
+    {
+        "category": "feminine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "system(s)",
+        "word_welsh": "system(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "cyclist(s)",
+        "word_welsh": "beiciwr (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "chairperson(s)",
+        "word_welsh": "cadeirydd(ion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "background(s)",
+        "word_welsh": "cefndir(oedd)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "edge(s), fringe(s)",
+        "word_welsh": "cwr (cyrion)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "interviewer(s)",
+        "word_welsh": "cyfwelydd (-wyr)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "charge(s), accusation(s)",
+        "word_welsh": "cyhuddiad(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "error(s)",
+        "word_welsh": "gwall(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "root(s)",
+        "word_welsh": "gwraidd (gwreiddiau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "self-confidence",
+        "word_welsh": "hunanhyder"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "pros and cons",
+        "word_welsh": "manteision ac anfanteision"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "aim(s), goal(s)",
+        "word_welsh": "nod(au)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "discussion point(s)",
+        "word_welsh": "pwynt(iau) trafod"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "zoo(s)",
+        "word_welsh": "sŵ (sweddau)"
+    },
+    {
+        "category": "masculine noun",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "type(s)",
+        "word_welsh": "teipen (teipiau)"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to register",
+        "word_welsh": "cofrestru"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to interview",
+        "word_welsh": "cyfweld"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to accuse",
+        "word_welsh": "cyhuddo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to fund",
+        "word_welsh": "cyllido"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to approve",
+        "word_welsh": "cymeradwyo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to say goodbye",
+        "word_welsh": "ffarwelio"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to facilitate",
+        "word_welsh": "hwyluso"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to sub-title",
+        "word_welsh": "is-deitlo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to succeed",
+        "word_welsh": "llwyddo"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to pass (exam)",
+        "word_welsh": "pasiro"
+    },
+    {
+        "category": "verb",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to perform",
+        "word_welsh": "perfformio"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "definite; firm",
+        "word_welsh": "pendant"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "relevant",
+        "word_welsh": "perthnasol"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "deliberate; cautious",
+        "word_welsh": "pwyllog"
+    },
+    {
+        "category": "adjective",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "likely",
+        "word_welsh": "tebygol"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "in order to",
+        "word_welsh": "er mwyn"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "how many...?",
+        "word_welsh": "faint o...?"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "sub-titles",
+        "word_welsh": "is-deitlau"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "to take advantage of",
+        "word_welsh": "manteisio ar"
+    },
+    {
+        "category": "other",
+        "level": "canolradd",
+        "unit": "arholiad",
+        "word_english": "as a result of",
+        "word_welsh": "o ganlyniad i"
+    }
+]


### PR DESCRIPTION
Implements a full-featured iOS version of the Geirfa flashcard app
using SwiftUI, matching the web app's core functionality: flip card
and typing modes, spaced repetition with Leitner boxes, unit-based
progression, Welsh digraph-aware hints, review mode for overdue
cards, and confetti mastery celebrations. Uses UserDefaults for
persistence and bundles the same vocabulary.json data.

https://claude.ai/code/session_01NMbM3VfvF6wTisNLcyXuRr