### PR TITLE
Show global green word count in subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -604,6 +604,7 @@ function renderSRStats() {
       ? (lang === 'cy' ? `Adolygu ${counts[i]} gair ${pileLabels[i].toLowerCase()}` : `Review ${counts[i]} ${pileLabels[i].toLowerCase()} word${counts[i] !== 1 ? 's' : ''}`)
       : '';
   });
+  updateWordCount();
 }
 
 function showRatingButtons(show) {
@@ -725,12 +726,17 @@ function refreshUnitBar() {
 }
 
 // ── Word count in subtitle ────────────────────────────────────────────────────
-// Shows total words across ALL units in the current level (not just the active unit).
-// Currently there is only one level (Canolradd), so this is always 908.
+// Shows total words and global "Known" (green) count across ALL units.
 function updateWordCount() {
-  const count = ALL_VOCAB.length;
+  const total = ALL_VOCAB.length;
+  const green = ALL_VOCAB.filter((_, i) => srPiles[String(i)] === 2).length;
   const el = document.getElementById('wordCountLabel');
-  if (el) el.textContent = count + (lang === 'cy' ? ' gair' : ' words');
+  if (!el) return;
+  if (green > 0) {
+    el.textContent = green + ' / ' + total + (lang === 'cy' ? ' wedi dysgu' : ' known');
+  } else {
+    el.textContent = total + (lang === 'cy' ? ' gair' : ' words');
+  }
 }
 
 function setUnit(unit, btn) {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'geirfa-v13';
+const CACHE = 'geirfa-v14';
 const PRECACHE = ['./index.html', './vocabulary.json', './favicon.svg', './apple-touch-icon.png', './manifest.json'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
## What this does

The subtitle under "Geirfa" now shows how many words out of the total you've marked as **Got it** (green/pile 2).

- Before any progress: shows **908 words** (unchanged)
- Once you start marking words green: switches to e.g. **372 / 908 known**
- In Welsh mode: **372 / 908 wedi dysgu**
- Resets back to "908 words" if you clear all progress

The count is global — across all units, not filtered to the active unit. It updates instantly on every rating.

## Implementation

-  now computes 
- Added a call to  at the end of , which is triggered after every card rating
- Cache version bumped to v14

https://claude.ai/code/session_012ynbBTD7kqWnpMJScnz2E5