### PR TITLE
Add tappable word list overlay for level

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
   .wordlist-header h2 { font-family: 'Playfair Display', serif; font-size: 1.5rem; color: var(--dark); margin-bottom: 4px; }
   .wordlist-header p { font-size: 0.82rem; color: var(--mid); letter-spacing: 0.06em; }
   .wordlist-body { overflow-y: auto; padding: 8px 28px 20px; flex: 1; -webkit-overflow-scrolling: touch; }
-  .wordlist-unit-heading { font-family: 'Source Sans 3', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--mid); margin: 20px 0 6px; padding-bottom: 4px; border-bottom: 1px solid var(--light); }
+  .wordlist-unit-heading { font-family: 'Source Sans 3', sans-serif; font-size: 0.92rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--mid); margin: 20px 0 6px; padding-bottom: 4px; border-bottom: 1px solid var(--light); }
   .wordlist-unit-heading:first-child { margin-top: 8px; }
   .wordlist-cat-heading { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; margin: 12px 0 4px; padding: 2px 10px; border-radius: 20px; display: inline-block; }
   .wordlist-cat-feminine  { background: #f8d7da; color: var(--col-fem); }

--- a/index.html
+++ b/index.html
@@ -188,8 +188,11 @@
   .wordlist-cat-adjective { background: #d5f0de; color: var(--col-adj); }
   .wordlist-cat-verb      { background: #e8e8e8; color: var(--col-verb); }
   .wordlist-cat-other     { background: #e8dff2; color: var(--col-other); }
-  .wordlist-word { display: flex; justify-content: space-between; gap: 12px; padding: 4px 0; font-size: 0.88rem; line-height: 1.4; border-bottom: 1px solid #f2efea; }
+  .wordlist-word { display: flex; justify-content: space-between; gap: 12px; padding: 4px 0; padding-left: 6px; font-size: 0.88rem; line-height: 1.4; border-bottom: 1px solid #f2efea; border-left: 3px solid transparent; }
   .wordlist-word:last-child { border-bottom: none; }
+  .wordlist-word.wl-hard  { border-left-color: #f8d7da; }
+  .wordlist-word.wl-okay  { border-left-color: #fff3cd; }
+  .wordlist-word.wl-known { border-left-color: #d1e7dd; }
   .wordlist-welsh { font-weight: 600; color: var(--dark); flex: 1; }
   .wordlist-english { color: var(--mid); flex: 1; text-align: right; }
   .wordlist-close { display: block; margin: 12px auto 0; background: var(--hgreen); color: white; border: none; border-radius: 10px; padding: 10px 28px; font-family: 'Source Sans 3', sans-serif; font-size: 0.9rem; font-weight: 700; cursor: pointer; transition: background .18s; flex-shrink: 0; }
@@ -1179,14 +1182,16 @@ function showWordList() {
   let html = '';
   units.forEach(unit => {
     const unitLabel = isNaN(parseInt(unit)) ? unit.charAt(0).toUpperCase() + unit.slice(1) : t('unitLabel') + ' ' + unit;
-    const words = ALL_VOCAB.filter(v => v.u === unit);
+    const words = ALL_VOCAB.map((v, i) => ({ ...v, _idx: i })).filter(v => v.u === unit);
     html += '<div class="wordlist-unit-heading">' + unitLabel + ' (' + words.length + ')</div>';
     catOrder.forEach(cat => {
       const catWords = words.filter(v => v.g === cat);
       if (catWords.length === 0) return;
       html += '<div class="wordlist-cat-heading ' + catClass[cat] + '">' + catLabel[cat] + '</div>';
       catWords.forEach(w => {
-        html += '<div class="wordlist-word"><span class="wordlist-welsh">' + w.c.replace(/</g, '&lt;') + '</span><span class="wordlist-english">' + w.e.replace(/</g, '&lt;') + '</span></div>';
+        const pile = srPiles[String(w._idx)];
+        const srCls = pile === 0 ? ' wl-hard' : pile === 1 ? ' wl-okay' : pile === 2 ? ' wl-known' : '';
+        html += '<div class="wordlist-word' + srCls + '"><span class="wordlist-welsh">' + w.c.replace(/</g, '&lt;') + '</span><span class="wordlist-english">' + w.e.replace(/</g, '&lt;') + '</span></div>';
       });
     });
   });

--- a/index.html
+++ b/index.html
@@ -172,6 +172,29 @@
   .complete-banner .btn-review:hover { background: rgba(255,255,255,.3); }
   .complete-banner .btn-review:disabled { opacity: 0.35; cursor: default; }
   .complete-banner .banner-actions { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; }
+  .subtitle { cursor: pointer; transition: color .18s; }
+  .subtitle:hover { color: var(--hgreen); }
+  .wordlist-overlay { position: fixed; inset: 0; z-index: 999; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,.45); animation: fadeInOverlay .3s ease; }
+  .wordlist-panel { background: white; border-radius: 20px; padding: 28px 0; max-width: 520px; width: 92%; max-height: 85vh; display: flex; flex-direction: column; box-shadow: 0 24px 64px rgba(0,0,0,.25); animation: popIn .4s cubic-bezier(.2,1.4,.4,1); }
+  .wordlist-header { text-align: center; padding: 0 28px 16px; border-bottom: 1.5px solid var(--light); flex-shrink: 0; }
+  .wordlist-header h2 { font-family: 'Playfair Display', serif; font-size: 1.5rem; color: var(--dark); margin-bottom: 4px; }
+  .wordlist-header p { font-size: 0.82rem; color: var(--mid); letter-spacing: 0.06em; }
+  .wordlist-body { overflow-y: auto; padding: 8px 28px 20px; flex: 1; -webkit-overflow-scrolling: touch; }
+  .wordlist-unit-heading { font-family: 'Source Sans 3', sans-serif; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--mid); margin: 20px 0 6px; padding-bottom: 4px; border-bottom: 1px solid var(--light); }
+  .wordlist-unit-heading:first-child { margin-top: 8px; }
+  .wordlist-cat-heading { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; margin: 12px 0 4px; padding: 2px 10px; border-radius: 20px; display: inline-block; }
+  .wordlist-cat-feminine  { background: #f8d7da; color: var(--col-fem); }
+  .wordlist-cat-masculine { background: #d4e6f1; color: var(--col-masc); }
+  .wordlist-cat-adjective { background: #d5f0de; color: var(--col-adj); }
+  .wordlist-cat-verb      { background: #e8e8e8; color: var(--col-verb); }
+  .wordlist-cat-other     { background: #e8dff2; color: var(--col-other); }
+  .wordlist-word { display: flex; justify-content: space-between; gap: 12px; padding: 4px 0; font-size: 0.88rem; line-height: 1.4; border-bottom: 1px solid #f2efea; }
+  .wordlist-word:last-child { border-bottom: none; }
+  .wordlist-welsh { font-weight: 600; color: var(--dark); flex: 1; }
+  .wordlist-english { color: var(--mid); flex: 1; text-align: right; }
+  .wordlist-close { display: block; margin: 12px auto 0; background: var(--hgreen); color: white; border: none; border-radius: 10px; padding: 10px 28px; font-family: 'Source Sans 3', sans-serif; font-size: 0.9rem; font-weight: 700; cursor: pointer; transition: background .18s; flex-shrink: 0; }
+  .wordlist-close:hover { background: #14552f; }
+  @media (max-width: 480px) { .wordlist-panel { width: 96%; max-height: 90vh; padding: 20px 0; } .wordlist-body { padding: 8px 18px 16px; } .wordlist-header { padding: 0 18px 12px; } }
 </style>
 </head>
 <body>
@@ -179,7 +202,7 @@
 <header>
   <img class="header-dragon" src="favicon.svg" alt="Welsh dragon" aria-hidden="true">
   <h1 data-i18n="title">Geirfa</h1>
-  <p class="subtitle"><span id="levelLabel">Canolradd</span> &middot; <span id="wordCountLabel">908 words</span></p>
+  <p class="subtitle" onclick="showWordList()"><span id="levelLabel">Canolradd</span> &middot; <span id="wordCountLabel">908 words</span></p>
   <div class="header-btns">
     <button class="lang-toggle" id="langToggle" onclick="toggleLang()">Cy</button>
     <button class="settings-toggle" id="settingsToggle" onclick="toggleSettings()" aria-label="Settings">&#9881;</button>
@@ -1145,6 +1168,40 @@ function toggleSettings() {
 }
 
 function toggleLang() { lang = lang === 'en' ? 'cy' : 'en'; applyLang(); }
+
+// ── Word list overlay ─────────────────────────────────────────────────────────
+function showWordList() {
+  const catOrder = ['feminine noun', 'masculine noun', 'adjective', 'verb', 'other'];
+  const catLabel = { 'feminine noun': lang === 'cy' ? 'Enw benywaidd' : 'Feminine noun', 'masculine noun': lang === 'cy' ? 'Enw gwrywaidd' : 'Masculine noun', adjective: lang === 'cy' ? 'Ansoddair' : 'Adjective', verb: lang === 'cy' ? 'Berf' : 'Verb', other: lang === 'cy' ? 'Arall' : 'Other' };
+  const catClass = { 'feminine noun': 'wordlist-cat-feminine', 'masculine noun': 'wordlist-cat-masculine', adjective: 'wordlist-cat-adjective', verb: 'wordlist-cat-verb', other: 'wordlist-cat-other' };
+
+  const units = getUnits();
+  let html = '';
+  units.forEach(unit => {
+    const unitLabel = isNaN(parseInt(unit)) ? unit.charAt(0).toUpperCase() + unit.slice(1) : t('unitLabel') + ' ' + unit;
+    const words = ALL_VOCAB.filter(v => v.u === unit);
+    html += '<div class="wordlist-unit-heading">' + unitLabel + ' (' + words.length + ')</div>';
+    catOrder.forEach(cat => {
+      const catWords = words.filter(v => v.g === cat);
+      if (catWords.length === 0) return;
+      html += '<div class="wordlist-cat-heading ' + catClass[cat] + '">' + catLabel[cat] + '</div>';
+      catWords.forEach(w => {
+        html += '<div class="wordlist-word"><span class="wordlist-welsh">' + w.c.replace(/</g, '&lt;') + '</span><span class="wordlist-english">' + w.e.replace(/</g, '&lt;') + '</span></div>';
+      });
+    });
+  });
+
+  const total = ALL_VOCAB.length;
+  const overlay = document.createElement('div');
+  overlay.className = 'wordlist-overlay';
+  overlay.innerHTML = '<div class="wordlist-panel">' +
+    '<div class="wordlist-header"><h2>Canolradd</h2><p>' + total + (lang === 'cy' ? ' gair' : ' words') + '</p></div>' +
+    '<div class="wordlist-body">' + html + '</div>' +
+    '<button class="wordlist-close" onclick="this.closest(\'.wordlist-overlay\').remove()">✓</button>' +
+    '</div>';
+  document.body.appendChild(overlay);
+  overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
+}
 
 loadVocab();
 

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'geirfa-v14';
+const CACHE = 'geirfa-v15';
 const PRECACHE = ['./index.html', './vocabulary.json', './favicon.svg', './apple-touch-icon.png', './manifest.json'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
## Summary
- Tapping the subtitle header ("Canolradd · 908 words") now opens a scrollable overlay listing every word in the level
- Words are grouped by unit, then sub-sorted by word type (feminine noun, masculine noun, adjective, verb, other)
- Each category has a colour-coded badge matching the existing card back colours
- Overlay dismisses by tapping the background or the close button
- Supports both English and Welsh UI language

## Test plan
- [ ] Tap the "Canolradd · X words" subtitle — overlay should appear with all 908 words
- [ ] Verify words are grouped under unit headings (Unit 1, Unit 2, … Arholiad)
- [ ] Verify within each unit, words are sub-grouped by type with coloured badges
- [ ] Scroll through the full list on mobile
- [ ] Tap outside the panel or the ✓ button to dismiss
- [ ] Switch to Welsh (Cy) and reopen — headings should be in Welsh
- [ ] Verify no interference with normal card flipping / unit selection

https://claude.ai/code/session_01HvK63ZnxoiimV652pUfQEk