### PR TITLE
Add export/import progress backup

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,9 @@
   <div class="sr-stat sr-hard"  id="srStatHard"  data-count="0" onclick="reviewByPile(0)" title=""><span id="srHard">0</span> <span data-i18n="hard">Hard</span></div>
   <div class="sr-stat sr-okay"  id="srStatOkay"  data-count="0" onclick="reviewByPile(1)" title=""><span id="srOkay">0</span> <span data-i18n="okay">Okay</span></div>
   <div class="sr-stat sr-known" id="srStatKnown" data-count="0" onclick="reviewByPile(2)" title=""><span id="srKnown">0</span> <span data-i18n="gotIt">Known</span></div>
+  <button class="btn-clear-data" onclick="exportProgress()" data-i18n="exportProgress">Export backup</button>
+  <input type="file" id="importFileInput" accept=".json" style="display:none" onchange="importProgress(event)">
+  <button class="btn-clear-data" onclick="document.getElementById('importFileInput').click()" data-i18n="importProgress">Import backup</button>
   <button class="btn-clear-data" onclick="clearAllData()" data-i18n="clearProgress">Clear all progress</button>
 </div>
 
@@ -508,6 +511,42 @@ function clearAllData() {
   buildChunkBar();
   updateCard();
   renderSRStats();
+}
+
+function exportProgress() {
+  const data = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    [STATE_KEY]:   storage.get(STATE_KEY, null),
+    [CARDS_KEY]:   storage.get(CARDS_KEY, {}),
+    [MASTERY_KEY]: storage.get(MASTERY_KEY, []),
+  };
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `geirfa-backup-${new Date().toISOString().slice(0, 10)}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function importProgress(event) {
+  const file = event.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = e => {
+    try {
+      const data = JSON.parse(e.target.result);
+      if (!data.version || !data[CARDS_KEY]) { alert(t('importInvalid')); return; }
+      if (!confirm(t('confirmImport'))) return;
+      if (data[STATE_KEY])   storage.set(STATE_KEY,   data[STATE_KEY]);
+      if (data[CARDS_KEY])   storage.set(CARDS_KEY,   data[CARDS_KEY]);
+      if (data[MASTERY_KEY]) storage.set(MASTERY_KEY, data[MASTERY_KEY]);
+      location.reload();
+    } catch { alert(t('importInvalid')); }
+  };
+  reader.readAsText(file);
+  event.target.value = '';
 }
 
 // ── Core state ────────────────────────────────────────────────────────────────
@@ -1247,6 +1286,9 @@ const TRANSLATIONS = {
     completedSet: "You've been through all the cards in this set.",
     reviewWeak: 'Retry difficult words', startAgain: 'Start again',
     allKnown: 'All cards marked as Got it!',
+    exportProgress: 'Export backup', importProgress: 'Import backup',
+    confirmImport: 'This will overwrite your current progress with the backup. Continue?',
+    importInvalid: 'Invalid backup file.',
     clearProgress: 'Clear all progress', kbFlip: 'flip',
     cardLangEn: 'English', cardLangCy: 'Welsh', startsWith: 'Starts with: ',
     correct: 'Correct!', notQuite: 'Not quite — the answer is: ',
@@ -1269,6 +1311,9 @@ const TRANSLATIONS = {
     completedSet: 'Rydych chi wedi gweld pob carden yn y set hon.',
     reviewWeak: 'Ailgynnig geiriau anodd', startAgain: 'Dechrau eto',
     allKnown: "Pob carden wedi'i marcio fel Wedi dysgu!",
+    exportProgress: 'Allforio copi', importProgress: 'Mewnforio copi',
+    confirmImport: 'Bydd hyn yn trosysgrifu eich cynnydd presennol. Parhau?',
+    importInvalid: 'Ffeil gopi annilys.',
     clearProgress: 'Dileu pob cynnydd', kbFlip: 'troi',
     cardLangEn: 'Saesneg', cardLangCy: 'Cymraeg', startsWith: 'Yn dechrau â: ',
     correct: 'Cywir!', notQuite: 'Nid yn iawn — yr ateb yw: ',

--- a/index.html
+++ b/index.html
@@ -241,6 +241,13 @@
         <button class="mode-btn"        id="modeType" onclick="setTypingMode(true)"  data-i18n="modeType">Typing</button>
       </div>
     </div>
+    <div class="settings-group">
+      <span class="settings-label" data-i18n="dataLabel">Data</span>
+      <input type="file" id="importFileInput" accept=".json" style="display:none" onchange="importProgress(event)">
+      <button class="btn-clear-data" onclick="exportProgress()" data-i18n="exportProgress">Export backup</button>
+      <button class="btn-clear-data" onclick="document.getElementById('importFileInput').click()" data-i18n="importProgress">Import backup</button>
+      <button class="btn-clear-data" onclick="clearAllData()" data-i18n="clearProgress">Clear all progress</button>
+    </div>
   </div>
 </div>
 
@@ -307,10 +314,6 @@
   <div class="sr-stat sr-hard"  id="srStatHard"  data-count="0" onclick="reviewByPile(0)" title=""><span id="srHard">0</span> <span data-i18n="hard">Hard</span></div>
   <div class="sr-stat sr-okay"  id="srStatOkay"  data-count="0" onclick="reviewByPile(1)" title=""><span id="srOkay">0</span> <span data-i18n="okay">Okay</span></div>
   <div class="sr-stat sr-known" id="srStatKnown" data-count="0" onclick="reviewByPile(2)" title=""><span id="srKnown">0</span> <span data-i18n="gotIt">Known</span></div>
-  <button class="btn-clear-data" onclick="exportProgress()" data-i18n="exportProgress">Export backup</button>
-  <input type="file" id="importFileInput" accept=".json" style="display:none" onchange="importProgress(event)">
-  <button class="btn-clear-data" onclick="document.getElementById('importFileInput').click()" data-i18n="importProgress">Import backup</button>
-  <button class="btn-clear-data" onclick="clearAllData()" data-i18n="clearProgress">Clear all progress</button>
 </div>
 
 <div class="key-hint"><kbd>Space</kbd> <span data-i18n="kbFlip">flip</span> &nbsp;&middot;&nbsp; <kbd>1</kbd> <span data-i18n="hard">Hard</span> &nbsp;&middot;&nbsp; <kbd>2</kbd> <span data-i18n="okay">Okay</span> &nbsp;&middot;&nbsp; <kbd>3</kbd> <span data-i18n="gotIt">Got it</span></div>
@@ -1286,6 +1289,7 @@ const TRANSLATIONS = {
     completedSet: "You've been through all the cards in this set.",
     reviewWeak: 'Retry difficult words', startAgain: 'Start again',
     allKnown: 'All cards marked as Got it!',
+    dataLabel: 'Data',
     exportProgress: 'Export backup', importProgress: 'Import backup',
     confirmImport: 'This will overwrite your current progress with the backup. Continue?',
     importInvalid: 'Invalid backup file.',
@@ -1311,6 +1315,7 @@ const TRANSLATIONS = {
     completedSet: 'Rydych chi wedi gweld pob carden yn y set hon.',
     reviewWeak: 'Ailgynnig geiriau anodd', startAgain: 'Dechrau eto',
     allKnown: "Pob carden wedi'i marcio fel Wedi dysgu!",
+    dataLabel: 'Data',
     exportProgress: 'Allforio copi', importProgress: 'Mewnforio copi',
     confirmImport: 'Bydd hyn yn trosysgrifu eich cynnydd presennol. Parhau?',
     importInvalid: 'Ffeil gopi annilys.',

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'geirfa-v17';
+const CACHE = 'geirfa-v18';
 const PRECACHE = ['./index.html', './vocabulary.json', './favicon.svg', './apple-touch-icon.png', './manifest.json'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
## Summary

- Adds **Export backup** and **Import backup** buttons next to *Clear all progress* in the stats bar
- Export downloads a JSON file named `geirfa-backup-YYYY-MM-DD.json` containing all card ratings, mastery data, and session state
- Import reads the file back, asks for confirmation, then restores everything and reloads the app
- Both buttons are translated into Welsh (Allforio copi / Mewnforio copi)
- Bumped service worker cache to `geirfa-v18`

## Test plan

- [ ] Click **Export backup** — a JSON file downloads
- [ ] Open the file and verify it contains `welsh_sr_cards`, `welsh_mastered_units`, `welsh_state`
- [ ] Click **Clear all progress** to wipe data
- [ ] Click **Import backup**, select the exported file — app reloads with progress restored
- [ ] Verify ratings and mastered units are back
- [ ] Try importing a non-JSON / wrong-format file — should show an alert, no crash
- [ ] Switch UI language to Welsh and verify translated button labels appear

https://claude.ai/code/session_01LgaQv6pt3rN9feVDnYJaVX